### PR TITLE
Auto-improve: process-self-critique

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -79,9 +79,26 @@ When deciding what to promote, weigh:
 - **Explicit signals** — user corrections and stated preferences are always high priority
 - **Impact** — does this affect how you should behave in future sessions?
 
+### 8. Produce Report
+
+Create both a markdown and JSON report per the MAINTENANCE.md reporting convention.
+
+**Markdown report:** `reports/YYYY-MM-DD-memory-consolidation.md`
+
+**JSON report:** `reports/YYYY-MM-DD-memory-consolidation.json`
+
+The JSON report MUST include a `processImprovements` field with at least one genuine `[self-critique]` entry. This entry must question whether the maintenance process is actually working — not just confirm that it ran. Examples of valid self-critique:
+
+- `[self-critique] Daily logs are accumulating faster than consolidation can process them — the 30-day compression threshold may be too lenient`
+- `[self-critique] The same recurring patterns keep appearing in daily logs, suggesting they aren't being promoted to semantic memory effectively`
+- `[self-critique] Core memory entries are growing stale — no mechanism exists to detect when promoted facts become outdated`
+- `[self-critique] Consolidation is running but memory retrieval quality hasn't been validated — promoted facts may not be surfaced in practice`
+
+**Do NOT use generic filler** like "ran consolidation as scheduled" or repeat the operational status. The self-critique must identify a real gap, recurring problem, or process weakness observed during this consolidation run.
+
 ## Commit
 
-After consolidation, commit all changes:
+After consolidation, commit all changes (including reports) in a single commit:
 ```
 chore: consolidate memory (YYYY-MM-DD)
 ```


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** process-self-critique
**Eval date:** 2026-04-07
**Overall score:** 0.9274

### Recent Eval History
- actionable-recommendations: 60%
- assess-memory-quality: 60%
- concrete-improvement-proposal: 75%
- meaningful-decisions: 100%
- no-data-loss: 60%
- previous-recommendations-reviewed: 75%
- process-self-critique: 28% <-- TARGET
- reduce-log-count: 99%
- update-relevant-tiers: 98%

### What Changed
## Improvement Summary

**Target criterion:** process-self-critique
**Files modified:** skills/memory/consolidate/skill.md

### What changed
Added an explicit step 8 ("Produce Report") to the memory consolidation skill, instructing the agent to generate both markdown and JSON reports per MAINTENANCE.md convention. The new step specifically requires a `processImprovements` field with at least one genuine `[self-critique]` entry, along with concrete examples of what qualifies as valid self-critique and an explicit warning against generic filler.

### Skill Impact
**Skill:** memory/consolidate — Memory consolidation procedure for processing daily logs into long-term memory
**Behavior change:** The consolidation skill will now explicitly produce the required JSON report including a `processImprovements` field with a genuine process self-critique entry. Previously, the skill had no report-generation step at all, so the brain had no guidance to produce the JSON report or populate `processImprovements` with substantive critique.

### Expected impact
Consolidation reports should now consistently include at least one `[self-critique]` entry that identifies a real process gap or recurring problem, improving the process-self-critique pass rate from the current ~45% (28% historical avg) toward a much higher rate.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*