### PR TITLE
Auto-improve: reduce-log-count

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -126,7 +126,7 @@ These criteria are used for self-assessment in the JSON report's `selfAssessment
 
 | ID | Criterion | Pass condition |
 |----|-----------|----------------|
-| `reduce-log-count` | Did consolidation reduce the number of daily log files? | At least one daily log was processed/archived |
+| `reduce-log-count` | Did consolidation leave no stale daily logs? | No daily log files older than 30 days remain after consolidation. If no logs are old enough to archive, this is a pass. |
 | `update-relevant-tiers` | Were all relevant memory tiers updated? | Changes propagated to appropriate tier (daily -> core, daily -> episodic, etc.) |
 | `meaningful-decisions` | Were decisions documented and non-trivial? | At least one decision in the report describes a real choice (not "did routine maintenance") |
 | `process-self-critique` | Did the consolidation report include process self-critique? | Report contains at least one entry questioning whether the current maintenance process is working, identifying a meta-level gap or recurring problem (not just operational status) |


### PR DESCRIPTION
## Auto-Improvement


**Target criterion:** reduce-log-count
**Eval date:** 2026-04-11
**Overall score:** 0.8753

### Recent Eval History
- actionable-recommendations: 67%
- assess-memory-quality: 67%
- concrete-improvement-proposal: 67%
- meaningful-decisions: 100%
- no-data-loss: 67%
- previous-recommendations-reviewed: 60%
- process-self-critique: 58%
- reduce-log-count: 83% <-- TARGET
- update-relevant-tiers: 83%

### What Changed
## Improvement Summary

**Target criterion:** reduce-log-count
**Files modified:** MAINTENANCE.md

### What changed

Updated the `reduce-log-count` pass condition in the Consolidation Criteria table from:

> "At least one daily log was processed/archived"

to:

> "No daily log files older than 30 days remain after consolidation. If no logs are old enough to archive, this is a pass."

### Why

The previous pass condition measured **activity** (whether consolidation archived at least one log). Most brains don't accumulate logs older than 30 days, so consolidation correctly found nothing to archive — but the criterion scored that as a fail, producing a 38.9% pass rate.

The new condition measures **outcome**: are there any stale logs (>30 days) remaining? Brains with no old logs pass by default, which correctly reflects healthy state. Only brains that neglected to clean up genuinely old logs will fail.

This aligns with admin steering directive #36 ("reduce-log-count measures activity instead of outcome").

### Report insights

No specific recommendations were found in today's report insights (no recommendations or observations in the 28 reports).

### Expected impact

The pass rate for `reduce-log-count` should rise significantly from 38.9% toward the historical average of 83.1%, since brains that are up-to-date on consolidation will now correctly self-assess as passing even when there are no old logs to archive.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*