### PR TITLE
Auto-improve: reduce-log-count

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -149,6 +149,7 @@ These criteria are used for self-assessment in the JSON report's `selfAssessment
 
 - **Memory consolidation**: Run `bash scripts/maintenance-guard.sh` first. If it exits non-zero, skip consolidation entirely (no report needed). If it exits 0, run the memory-consolidate skill to process daily logs into long-term memory. **Produce a report.**
   - **Tier coverage check**: Before completing consolidation, verify that each memory tier was explicitly considered: `memory/semantic/` (facts/knowledge), `memory/episodic/` (significant events), `memory/procedural/` (workflows), `memory/core/` (corrections, preferences, lessons). If any daily log contains information relevant to a tier, that tier MUST be updated. Do not stop after updating one tier — check all four.
+  - **Log age check**: Before writing the report, check whether any `memory/daily/*.md` files are dated more than 30 days ago. If none are, self-assess `reduce-log-count: true` — the outcome is satisfied and no archiving action is required. Only archive logs if files genuinely older than 30 days exist. Record the outcome explicitly in the report: either "archived N stale logs" or "no daily logs older than 30 days found".
 
 ## Twice Weekly
 


### PR DESCRIPTION
## Auto-Improvement


**Target criterion:** reduce-log-count
**Eval date:** 2026-04-11
**Overall score:** 0.8753

### Recent Eval History
- actionable-recommendations: 67%
- assess-memory-quality: 67%
- concrete-improvement-proposal: 67%
- meaningful-decisions: 100%
- no-data-loss: 67%
- previous-recommendations-reviewed: 60%
- process-self-critique: 58%
- reduce-log-count: 83% <-- TARGET
- update-relevant-tiers: 83%

### What Changed
## Improvement Summary

**Target criterion:** reduce-log-count
**Files modified:** MAINTENANCE.md

### What changed

Added a **Log age check** instruction to the Daily consolidation section in MAINTENANCE.md. The new bullet explicitly tells the brain to:
1. Check whether any `memory/daily/*.md` files are dated more than 30 days ago before writing the report
2. Self-assess `reduce-log-count: true` when no stale logs exist (outcome satisfied, no action needed)
3. Record the outcome explicitly in the report ("archived N stale logs" or "no daily logs older than 30 days found")

This complements the existing criterion table entry (which already says "If no logs are old enough to archive, this is a pass") by providing actionable runtime guidance during consolidation.

### Why this was needed

The criterion table was already updated to outcome-based language (by a prior improvement). However, brains still incorrectly set `reduce-log-count: false` in selfAssessment when consolidation ran but found nothing to archive. Without explicit procedural guidance, brains would either skip the check silently or assume "no archiving = fail."

The steering directive (#36) confirmed that most brains don't accumulate 30+ day old logs, so the correct behavior is to verify log age and pass when none are stale — not to require archiving activity to pass.

### Expected impact

Brains running consolidation will now explicitly verify log age and correctly self-assess `reduce-log-count: true` when no stale logs exist. This should improve the pass rate from ~39% toward the historical average of ~83% and beyond, since the failure mode was brains incorrectly reporting failure on a condition they actually satisfied.

### Report insights

No observations or recommendations were found in today's report-insights.md, so the change is based entirely on steering directive #36 and the current criterion pass condition.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*