### PR TITLE
Auto-improve: reduce-log-count

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -57,12 +57,13 @@ Route new/updated facts to appropriate locations:
 After promoting facts, update `MEMORY.md` to reflect the current state of memory.
 Keep it concise — topic summaries with pointers to detail files.
 
-### 6. Compress Old Daily Logs
+### 6. Archive Old Daily Logs
 
-For daily logs older than 30 days:
-- Create `memory/daily/weekly-YYYY-Www.md` summaries (one per week)
-- Delete the individual daily files that were summarized
-- Keep the weekly summary concise (key events and learnings only)
+For daily log files (format: `YYYY-MM-DD.md`) in `memory/daily/` that are older than 30 days:
+- **Delete them.** Their content has already been promoted to long-term memory in steps 2–4.
+- Do NOT create weekly summary files (`weekly-*.md`) — they accumulate in `memory/daily/` and eventually become stale files themselves, causing this step to fail in future runs.
+- If any weekly summary files from a previous approach still exist in `memory/daily/` and are older than 30 days, delete those too.
+- After deletion, verify no files dated more than 30 days ago remain in `memory/daily/`.
 
 ### 7. Update Timestamp
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** reduce-log-count
**Eval date:** 2026-04-12
**Overall score:** 0.8819

### Recent Eval History
- actionable-recommendations: 83%
- assess-memory-quality: 83%
- concrete-improvement-proposal: 83%
- meaningful-decisions: 100%
- no-data-loss: 83%
- previous-recommendations-reviewed: 77%
- process-self-critique: 72%
- reduce-log-count: 73% <-- TARGET
- update-relevant-tiers: 78%

### What Changed
## Improvement Summary

**Target criterion:** reduce-log-count
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Modified step 6 ("Compress Old Daily Logs" → "Archive Old Daily Logs") to delete old daily logs directly instead of compressing them into weekly summary files.

The previous approach created `memory/daily/weekly-YYYY-Www.md` summaries for old daily logs. These summaries accumulated in `memory/daily/` and after 30+ days THEY became "daily log files older than 30 days" — causing the criterion to fail in subsequent consolidation runs. This created a self-defeating cycle: archiving logs via weekly summaries replaced one set of old files with another.

The fix: since daily log facts are already promoted to long-term memory (semantic/episodic/procedural/core) in steps 2–4, weekly summaries are redundant. Old logs can simply be deleted. An additional instruction cleans up any existing weekly summary files that may have already accumulated.

### Why MAINTENANCE.md changes (PRs #23 and #24) didn't fix it

Both previous PRs modified MAINTENANCE.md to add a log-age check instruction and update the criterion description. These improvements were correct but didn't address the root cause: the consolidate skill was generating the very files (weekly summaries) that would eventually fail the criterion in future runs.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure run during maintenance heartbeat

**Behavior change:** Step 6 no longer creates `weekly-YYYY-Www.md` summary files. Old daily logs (>30 days) are deleted directly. The skill also cleans up any leftover weekly summary files from the old approach. This ensures `memory/daily/` contains only recent log files after each consolidation run.

### Expected impact

The reduce-log-count criterion should pass consistently once the weekly summary accumulation is eliminated. The latest score of 31.25% should recover toward the historical average of ~73% and beyond, since the root cause of accumulating stale files is now addressed.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*