### PR TITLE
Auto-improve: reduce-log-count

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -105,6 +105,8 @@ Create both a markdown and JSON report:
 
 The JSON report MUST include the `processImprovements` field with the `[self-critique]` entry from Step 8.
 
+For `selfAssessment.reduce-log-count`: set to `true` if Step 6 left no daily logs older than 30 days in `memory/daily/` — this includes the case where you checked and found none to delete. Set to `false` only if old logs still remain after your run.
+
 ## Scoring Guidance
 
 When deciding what to promote, weigh:


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** reduce-log-count
**Eval date:** 2026-04-13
**Overall score:** 0.8978

### Recent Eval History
- actionable-recommendations: 83%
- assess-memory-quality: 83%
- concrete-improvement-proposal: 83%
- meaningful-decisions: 100%
- no-data-loss: 83%
- previous-recommendations-reviewed: 77%
- process-self-critique: 83%
- reduce-log-count: 67% <-- TARGET
- update-relevant-tiers: 72%

### What Changed
## Improvement Summary

**Target criterion:** reduce-log-count
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Added explicit `selfAssessment.reduce-log-count` guidance to the consolidation skill's Step 9 (Produce Report). The new text clarifies:
- Set to `true` if Step 6 left no daily logs older than 30 days — including the case where none needed deleting
- Set to `false` only if old logs still remain after the run

### Why this approach

MAINTENANCE.md (the specific scope target) already contains this guidance and has been targeted by 3 prior improvement attempts with no meaningful score improvement (still at 0.52). This indicates the MAINTENANCE.md instruction is not being applied at execution time, likely because agents follow the skill's step-by-step procedure rather than cross-referencing MAINTENANCE.md mid-task.

By adding the self-assessment rule directly inside the skill's reporting step, the guidance appears at the exact moment the agent fills in the JSON `selfAssessment` field — eliminating the need to recall MAINTENANCE.md content from another file.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure (daily maintenance)
**Behavior change:** The skill's Step 9 now explicitly tells agents how to evaluate `reduce-log-count` for self-assessment. Previously, agents had to infer this from MAINTENANCE.md; now the rule is co-located with the action. The key clarification is that finding no stale logs counts as a pass (should be `true`), not just when logs were actively deleted.

### Expected impact

Agents that correctly complete Step 6 (archive check) but then incorrectly self-assess `false` — because they "didn't delete anything" — should now self-assess `true`. This should raise the pass rate from the current 0.52 toward the historical average of 0.67 and potentially higher.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*