### PR TITLE
fix(memory): enforce daily log scratchpad + observable compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ Your workspace has a tiered memory system. See the `memory` skill for full docum
 
 **NEVER write to `memory/semantic/`, `memory/episodic/`, or `memory/procedural/` during regular sessions.** Those are populated only during maintenance consolidation.
 
+**NEVER delete today's or yesterday's `memory/daily/*.md` during maintenance** — same-day and next-day sessions rely on them for context recovery. Promotion to long-term memory is not a reason to delete recent logs. Only files dated 30+ days ago are candidates for deletion.
+
 **Searching:** Use Grep/Glob to search `memory/semantic/`, `memory/episodic/`, `memory/procedural/` when you need deeper context.
 
 ## Scheduled Messages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,11 +98,13 @@ Your workspace has a tiered memory system. See the `memory` skill for full docum
 2. `memory/core/*.md` — curated long-term memory
 3. `memory/daily/` — today's and yesterday's logs
 
+**Daily log = your running scratchpad.** As you work, append one-liners to `memory/daily/YYYY-MM-DD.md` whenever something is worth remembering tomorrow: a decision, a correction, a surprising finding, a completed task. Append *continuously* during the session — don't batch at the end, and don't skip because "nothing important happened yet." If the session involves tool use or a real exchange, it almost always produces at least one line worth keeping.
+
 **Where to write (regular sessions — ONLY these two locations):**
 - Corrections → `memory/core/MISTAKES.md`
 - Preferences → `memory/core/PREFERENCES.md`
 - Lessons learned → `memory/core/LEARNINGS.md`
-- **Everything else** → `memory/daily/YYYY-MM-DD.md` (daily log)
+- **Everything else** → `memory/daily/YYYY-MM-DD.md`
 
 **NEVER write to `memory/semantic/`, `memory/episodic/`, or `memory/procedural/` during regular sessions.** Those are populated only during maintenance consolidation.
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -87,7 +87,11 @@ The JSON file is written at the same time as the markdown report, in the same co
     "reduce-log-count": true,
     "update-relevant-tiers": true,
     "meaningful-decisions": true,
-    "no-data-loss": true
+    "no-data-loss": true,
+    "daily-log-exists-today": true,
+    "daily-log-continuous-appends": true,
+    "daily-log-recent-retention": true,
+    "daily-log-weekly-coverage": true
   },
   "processImprovements": [
     "[self-critique] What is not working in my maintenance process? What am I ignoring?",
@@ -130,6 +134,10 @@ These criteria are used for self-assessment in the JSON report's `selfAssessment
 | `update-relevant-tiers` | Were all relevant memory tiers updated? | Changes propagated to appropriate tier (daily -> core, daily -> episodic, etc.) |
 | `meaningful-decisions` | Were decisions documented and non-trivial? | At least one decision in the report describes a real choice (not "did routine maintenance") |
 | `process-self-critique` | Did the consolidation report include process self-critique? | Report contains at least one entry questioning whether the current maintenance process is working, identifying a meta-level gap or recurring problem (not just operational status) |
+| `daily-log-exists-today` | Is today's daily log present? | If any session ran today (git commits or reports from today exist), `memory/daily/YYYY-MM-DD.md` for today exists and is non-empty. If today had no sessions yet, this is a pass. |
+| `daily-log-continuous-appends` | Was today's log appended to continuously, not written once? | Today's `memory/daily/YYYY-MM-DD.md` contains 2+ distinct entries (e.g., dated or bulleted lines). A single session-end dump fails this criterion. If today had fewer than 2 sessions, the criterion evaluates the most recent day with 2+ sessions instead. |
+| `daily-log-recent-retention` | Are today's and yesterday's logs preserved? | After consolidation, both `memory/daily/<today>.md` and `memory/daily/<yesterday>.md` still exist (if they existed before consolidation or were created today). Consolidation MUST NOT delete them. |
+| `daily-log-weekly-coverage` | Is daily log coverage healthy across the last 7 days? | Over the last 7 days, the ratio `days_with_daily_log / days_with_any_session` is ≥ 0.8. Days with no session do not count against coverage. |
 
 ### Reflection Criteria
 
@@ -150,6 +158,18 @@ These criteria are used for self-assessment in the JSON report's `selfAssessment
 - **Memory consolidation**: Run `bash scripts/maintenance-guard.sh` first. If it exits non-zero, skip consolidation entirely (no report needed). If it exits 0, run the memory-consolidate skill to process daily logs into long-term memory. **Produce a report.**
   - **Tier coverage check**: Before completing consolidation, verify that each memory tier was explicitly considered: `memory/semantic/` (facts/knowledge), `memory/episodic/` (significant events), `memory/procedural/` (workflows), `memory/core/` (corrections, preferences, lessons). If any daily log contains information relevant to a tier, that tier MUST be updated. Do not stop after updating one tier — check all four.
   - **Log age check**: Before writing the report, check whether any `memory/daily/*.md` files are dated more than 30 days ago. If none are, self-assess `reduce-log-count: true` — the outcome is satisfied and no archiving action is required. Only archive logs if files genuinely older than 30 days exist. Record the outcome explicitly in the report: either "archived N stale logs" or "no daily logs older than 30 days found".
+  - **Recent-log retention (never delete today or yesterday)**: Consolidation MUST NOT delete `memory/daily/<today>.md` or `memory/daily/<yesterday>.md`, regardless of whether their contents have been promoted. Same-day and next-day sessions rely on these files being present to recover context. Only logs dated 2+ days ago are candidates for promotion; only logs dated 30+ days ago are candidates for deletion.
+  - **Daily log compliance block**: Every consolidation report MUST include a `## Daily Log Compliance` section in the markdown with observable metrics for the last 7 days. If any metric fails, either backfill (reconstruct entries from git log / reports / this session's memory) or explicitly flag the gap in `processImprovements` as a `[self-critique]`. Example block:
+    ```markdown
+    ## Daily Log Compliance
+    - Coverage (last 7d): 5/7 days with sessions covered ✅
+    - Today's log: present, 8 entries, first append 09:14, last 16:42 ✅
+    - Continuous appends: 8 distinct timestamped entries (not a single end-of-session dump) ✅
+    - Retention: today + yesterday preserved ✅
+    - Empty/trivial logs: 0
+    - Gaps: 2026-04-11 (had sessions per git log, no daily log written)
+    ```
+    Populate the `selfAssessment` fields `daily-log-exists-today`, `daily-log-continuous-appends`, `daily-log-recent-retention`, and `daily-log-weekly-coverage` based on this block.
 
 ## Twice Weekly
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -134,10 +134,6 @@ These criteria are used for self-assessment in the JSON report's `selfAssessment
 | `update-relevant-tiers` | Were all relevant memory tiers updated? | Changes propagated to appropriate tier (daily -> core, daily -> episodic, etc.) |
 | `meaningful-decisions` | Were decisions documented and non-trivial? | At least one decision in the report describes a real choice (not "did routine maintenance") |
 | `process-self-critique` | Did the consolidation report include process self-critique? | Report contains at least one entry questioning whether the current maintenance process is working, identifying a meta-level gap or recurring problem (not just operational status) |
-| `daily-log-exists-today` | Is today's daily log present? | If any session ran today (git commits or reports from today exist), `memory/daily/YYYY-MM-DD.md` for today exists and is non-empty. If today had no sessions yet, this is a pass. |
-| `daily-log-continuous-appends` | Was today's log appended to continuously, not written once? | Today's `memory/daily/YYYY-MM-DD.md` contains 2+ distinct entries (e.g., dated or bulleted lines). A single session-end dump fails this criterion. If today had fewer than 2 sessions, the criterion evaluates the most recent day with 2+ sessions instead. |
-| `daily-log-recent-retention` | Are today's and yesterday's logs preserved? | After consolidation, both `memory/daily/<today>.md` and `memory/daily/<yesterday>.md` still exist (if they existed before consolidation or were created today). Consolidation MUST NOT delete them. |
-| `daily-log-weekly-coverage` | Is daily log coverage healthy across the last 7 days? | Over the last 7 days, the ratio `days_with_daily_log / days_with_any_session` is ≥ 0.8. Days with no session do not count against coverage. |
 
 ### Reflection Criteria
 

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -65,6 +65,8 @@ For daily log files (format: `YYYY-MM-DD.md`) in `memory/daily/` that are older 
 - If any weekly summary files from a previous approach still exist in `memory/daily/` and are older than 30 days, delete those too.
 - After deletion, verify no files dated more than 30 days ago remain in `memory/daily/`.
 
+**Recent-log retention (non-negotiable):** NEVER delete `memory/daily/<today>.md` or `memory/daily/<yesterday>.md`, regardless of whether their contents have been promoted. Same-day and next-day sessions rely on these files to recover context. Promotion is not a reason to delete; deletion is only for files dated 30+ days ago.
+
 ### 7. Update Timestamp
 
 Write the current date to `memory/.last_consolidation`:
@@ -72,7 +74,33 @@ Write the current date to `memory/.last_consolidation`:
 YYYY-MM-DD
 ```
 
-### 8. Process Self-Critique
+### 8. Assess Daily Log Compliance
+
+Before self-critique, run observable checks on the daily log scratchpad and record the outcome in both reports.
+
+Checks (all over the last 7 days unless specified):
+
+1. **Today's log exists.** If any session ran today (commits, reports, or MCP tool calls today), verify `memory/daily/YYYY-MM-DD.md` for today exists and has non-empty content. If no sessions ran today, pass.
+2. **Continuous appends.** Today's log (or the most recent day that had 2+ sessions) contains 2+ distinct timestamped or bulleted entries — not a single dump. A file with a lone session-end paragraph fails this check.
+3. **Retention.** Both `memory/daily/<today>.md` and `memory/daily/<yesterday>.md` are present after consolidation completes.
+4. **No empty logs.** No `memory/daily/*.md` file is empty or contains only a header.
+5. **Weekly coverage.** Compute `days_with_daily_log / days_with_any_session` over the last 7 days. Target ≥ 0.8. "Days with sessions" = days with commits to this brain, reports written, or (if available) inbox activity.
+
+Write the result into the markdown report as a `## Daily Log Compliance` section (see example in MAINTENANCE.md). Populate the corresponding `selfAssessment` keys in the JSON report:
+
+- `daily-log-exists-today`
+- `daily-log-continuous-appends`
+- `daily-log-recent-retention`
+- `daily-log-weekly-coverage`
+
+If any check fails, do one of two things before finishing:
+
+- **Backfill** — if you can reconstruct entries from git log, reports, or this session's context, append them to the correct `memory/daily/*.md` file with a note that they were reconstructed (e.g., `- (backfilled from git) 15:30 — shipped PR #51`).
+- **Flag** — if backfill isn't possible, add a `[self-critique]` entry in `processImprovements` naming the specific gap and what prevented the agent from writing during that day.
+
+Do not silently pass a failing check.
+
+### 9. Process Self-Critique
 
 Before writing the report, reflect on whether the maintenance process itself is working. This is **required** — the JSON report's `processImprovements` field must contain at least one `[self-critique]` entry per consolidation run.
 
@@ -96,14 +124,12 @@ Example entries:
 - `"[self-critique] The same team project facts are re-extracted each cycle because they're not being promoted to semantic memory"`
 - `"[self-critique] Consolidation is running but memory retrieval quality hasn't been validated — promoted facts may not be surfaced in practice"`
 
-### 9. Produce Report
+### 10. Produce Report
 
 Create both a markdown and JSON report:
 
-- **Markdown:** `reports/YYYY-MM-DD-memory-consolidation.md`
-- **JSON:** `reports/YYYY-MM-DD-memory-consolidation.json`
-
-The JSON report MUST include the `processImprovements` field with the `[self-critique]` entry from Step 8.
+- **Markdown:** `reports/YYYY-MM-DD-memory-consolidation.md` (must include the `## Daily Log Compliance` section from Step 8)
+- **JSON:** `reports/YYYY-MM-DD-memory-consolidation.json` (must include `daily-log-*` keys in `selfAssessment` and the `[self-critique]` entry from Step 9 in `processImprovements`)
 
 ## Scoring Guidance
 

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -36,14 +36,20 @@ Do not announce that you're reading memory. Just do it.
 
 ## Daily Logging
 
-During each session, append observations to `memory/daily/YYYY-MM-DD.md`:
-- Key decisions made
-- New information learned about the team/project
-- Tasks completed or started
-- Corrections received
-- Important context from conversations
+The daily log is a **running scratchpad you append to throughout the session**, not a summary you write at the end. Treat it like thinking out loud to your future self.
 
-Format: use timestamps and brief entries. Create the file if it doesn't exist.
+As you work, append a timestamped one-liner to `memory/daily/YYYY-MM-DD.md` whenever any of these happen:
+- You make a decision (especially one you'd have to explain later)
+- The user corrects you or states a preference
+- You learn something about the team, project, or environment
+- You complete or start a task worth remembering tomorrow
+- Something surprising or non-obvious comes up
+
+Rules:
+- **Append continuously, not at the end.** If the session ends abruptly (crash, context compaction, timeout), the log still has value because you wrote as you went.
+- **Don't batch-decide "what was important."** If you're unsure whether an entry is worth it, write it — removing noise is cheap during consolidation, reconstructing lost context is not.
+- **One line per entry is fine.** Brief is better than nothing.
+- Create the file if it doesn't exist.
 
 ```markdown
 ## 2026-03-17
@@ -51,7 +57,10 @@ Format: use timestamps and brief entries. Create the file if it doesn't exist.
 - 14:30 — Learned that Alice prefers email over Slack for approvals
 - 14:45 — Fixed the deploy script; root cause was missing AWS region
 - 15:10 — User corrected: reports should go to #general, not #reports
+- 15:42 — Tried to use `gh pr create --draft`; project convention is non-draft PRs
 ```
+
+**Anti-pattern:** finishing a session that involved real tool use (edits, commits, decisions) with zero daily log entries. If that happens, it means the scratchpad habit failed — fix it next session.
 
 ## Where to Write During Regular Sessions
 


### PR DESCRIPTION
## Summary

Addresses the core failure from teamvibeai/teamvibe.ai#48 and B1 in teamvibeai/teamvibe.ai#31: agents don't write daily logs, so same-day memory recall is broken and consolidation has no input.

Two shifts:
1. **Reframe the instruction.** Daily logs aren't an end-of-session report — they're a running scratchpad the agent appends to *throughout* the session. Passive "where to write" language is replaced with active "append continuously" framing, plus an explicit anti-pattern callout.
2. **Make compliance observable.** New checks and a ` + "`## Daily Log Compliance`" + ` report block let us see whether the guidance is being followed — coverage, continuous-append evidence, retention, today's presence.

## Changes

- ` + "`CLAUDE.md`" + ` — scratchpad framing in the Memory System section.
- ` + "`skills/memory/skill.md`" + ` — expanded Daily Logging with explicit rules and an anti-pattern example.
- ` + "`skills/memory/consolidate/skill.md`" + ` — new Step 8 \"Assess Daily Log Compliance\" (5 checks, backfill-or-flag behavior), non-negotiable retention safeguard in Step 6, renumbered steps 9–10.
- ` + "`MAINTENANCE.md`" + ` — retention rule (never delete today or yesterday), required \"Daily Log Compliance\" block in reports, new ` + "`daily-log-*`" + ` keys in the ` + "`selfAssessment`" + ` JSON schema.

## Coordinated PR

New eval criteria live in teamvibeai/poller-brain-eval: https://github.com/teamvibeai/poller-brain-eval/pulls — merge order is **brain first, eval second**, so the sync-criteria workflow regenerates MAINTENANCE.md's criteria tables against the now-compatible brain.

## Test plan

- [ ] After next heartbeat, verify a consolidation report contains the ` + "`## Daily Log Compliance`" + ` section.
- [ ] Verify ` + "`daily-log-*`" + ` keys appear in the JSON report's ` + "`selfAssessment`" + `.
- [ ] Verify today's and yesterday's logs survive consolidation.
- [ ] Give it 2–3 days: check whether ` + "`memory/daily/`" + ` across J.A.R.V.I.S. and RekapAI starts accumulating same-day entries (evidence #48 is actually fixed, not just the instruction updated).