### PR TITLE
Auto-improve: daily-log-weekly-coverage

### DIFF
--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -31,6 +31,7 @@ At the start of every session, silently load memory in this order:
 1. **`MEMORY.md`** (workspace root) — the index of what you know
 2. **`memory/core/*.md`** — all core memory files
 3. **`memory/daily/`** — today's log and yesterday's log (if they exist)
+4. **Create today's daily log entry** — immediately append at least one entry to `memory/daily/YYYY-MM-DD.md` (create the file if needed). Even a minimal entry like `- HH:MM — session started` is required. Do this BEFORE any other work.
 
 Do not announce that you're reading memory. Just do it.
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** daily-log-weekly-coverage
**Eval date:** 2026-04-15
**Overall score:** 0.87

### Recent Eval History
- actionable-recommendations: 83%
- assess-memory-quality: 83%
- concrete-improvement-proposal: 83%
- daily-log-continuous-appends: 60%
- daily-log-exists-today: 62%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 4% <-- TARGET
- evidence-backed-decisions: 100%
- meaningful-decisions: 100%
- no-data-loss: 83%
- previous-recommendations-reviewed: 77%
- process-self-critique: 99%
- reduce-log-count: 66%
- update-relevant-tiers: 73%

### What Changed
## Improvement Summary

**Target criterion:** daily-log-weekly-coverage
**Files modified:** skills/memory/skill.md

### What changed

Added step 4 to the Session Startup Loading section, explicitly requiring agents to create a daily log entry as part of session startup — before any other work begins. This applies to every session type: heartbeat, operational, ad-hoc, and automated.

### Why

The root cause of the daily-log-weekly-coverage failure (0% pass rate, 0.0405 historical avg) is structural: daily logs were only being created during heartbeat sessions. Operational sessions (triage, interactive work, code reviews, scheduled prompts) consistently skipped log creation because the minimum entry rule existed only in the "Daily Logging" narrative section — not as an explicit startup action.

Report insights confirmed this pattern across multiple consolidations:
- "Daily log coverage at 25% — far below 80% target. The gap is structural: only heartbeat sessions create daily logs."
- "Every session must append to memory/daily/YYYY-MM-DD.md as its first action — enforce by adding to session startup checklist"
- "Maintenance-only heartbeats should always create a minimal daily log entry to improve weekly coverage metric"

Embedding the daily log creation in the startup sequence (step 4) ensures it runs in every session regardless of session type, directly addressing the structural gap.

### Skill Impact

**Skill:** memory — Structured memory management system (always active)
**Behavior change:** Session startup now includes an explicit fourth step: create a daily log entry for today before doing any other work. This transforms daily logging from a "remember to do this" guideline into a mandatory startup action, matching how steps 1-3 (reading MEMORY.md, core files, and recent logs) are already treated.

### Expected impact

The brain should now create daily log entries across all session types, raising `days_with_daily_log / days_with_any_session` from the current ~25-43% toward the ≥80% target, improving the daily-log-weekly-coverage pass rate significantly.

### Report insights used

- Observation: "Daily log coverage at 25% (2/8 session-days covered) — far below 80% target. The gap is structural: only heartbeat sessions create daily logs, while operational sessions do not."
- Recommendation: "Every session (heartbeat, invest:check, ad-hoc) must append to memory/daily/YYYY-MM-DD.md as its first action — enforce by adding to session startup checklist"
- Recommendation: "Address daily log coverage gap by proposing a KB change: add a daily-log append step to operational skill templates"

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*