### PR TITLE
Sync eval criteria tables from criteria.json

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -138,6 +138,9 @@ These criteria are used for self-assessment in the JSON report's `selfAssessment
 | `daily-log-recent-retention` | Are today's and yesterday's daily logs preserved after consolidation? | After consolidation completes, memory/daily/<today>.md and memory/daily/<yesterday>.md still exist (when they existed before consolidation or were created today) |
 | `daily-log-weekly-coverage` | Is daily log coverage healthy across the last 7 days? | Over the last 7 days, days_with_daily_log / days_with_any_session >= 0.8. Days with no session do not count against coverage. |
 | `evidence-backed-decisions` | Did consolidation document at least two decisions with specific memory evidence? | At least 2 entries in the decisions array reference specific memory files, observed entry counts, or content patterns encountered during consolidation — not generic process descriptions |
+| `summary-md-regenerated` | Was memory/SUMMARY.md regenerated during consolidation? | memory/SUMMARY.md appears in filesChanged, indicating the consolidated long-term memory index was updated. If the brain has not yet migrated to the SUMMARY.md workflow (no memory/SUMMARY.md exists), this criterion passes — the migration will create it. |
+| `today-md-archived` | Was memory/TODAY.md archived and reset during consolidation? | memory/TODAY.md appears in filesChanged, indicating the daily working log was archived to memory/daily/ and reset for the new day. If the brain has not yet migrated to the TODAY.md workflow, this criterion passes. |
+| `at-imports-configured` | Are @memory/SUMMARY.md and @memory/TODAY.md imports configured in CLAUDE.md? | The consolidation report's Daily Log Compliance section or selfAssessment confirms that the channel brain CLAUDE.md contains both @memory/SUMMARY.md and @memory/TODAY.md references. If the brain has not yet migrated, this criterion passes. |
 
 ### Reflection Criteria
 


### PR DESCRIPTION
## Criteria Sync

This is an automated sync of the eval criteria tables in MAINTENANCE.md from the canonical `criteria/criteria.json` in the eval repo.

### Current Criteria
Active criteria: 16
  - reduce-log-count: At least one daily log was processed/archived
  - update-relevant-tiers: Changes propagated to appropriate tier (daily -> core, daily
  - process-self-critique: Report contains at least one entry questioning whether the c
  - concrete-improvement-proposal: Report includes at least one specific proposal for changing 
  - previous-recommendations-reviewed: Report explicitly references at least one recommendation fro
  - daily-log-exists-today: If any session ran today (commits, reports, or MCP activity 
  - daily-log-continuous-appends: Today's daily log (or the most recent day with 2+ sessions) 
  - daily-log-recent-retention: After consolidation completes, memory/daily/<today>.md and m
  - daily-log-weekly-coverage: Over the last 7 days, days_with_daily_log / days_with_any_se
  - evidence-backed-decisions: At least 2 entries in the decisions array reference specific
  - gap-impact-analysis: At least one entry in observations identifies a specific mem
  - verifiable-recommendations: At least one entry in recommendations specifies: (1) a concr
  - deletion-with-preservation-evidence: For every file deletion recorded in filesChanged (operationC
  - summary-md-regenerated: memory/SUMMARY.md appears in filesChanged, indicating the co
  - today-md-archived: memory/TODAY.md appears in filesChanged, indicating the dail
  - at-imports-configured: The consolidation report's Daily Log Compliance section or s

### What Changed
The Consolidation Criteria and/or Reflection Criteria tables in the Eval Criteria section of MAINTENANCE.md have been updated to match the current criteria.json registry.

---
*Auto-generated by sync-criteria workflow. This PR can be auto-merged (mechanical sync per D-11).*