### PR TITLE
Auto-improve: daily-log-weekly-coverage

### DIFF
--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -56,7 +56,7 @@ As you work, append a timestamped one-liner to **`memory/TODAY.md`** whenever an
 
 Rules:
 - **Write to `memory/TODAY.md`** — this is the primary daily log target. It gets archived to `memory/daily/YYYY-MM-DD.md` during maintenance.
-- **Minimum entry rule (non-negotiable):** Every session must create at least one log entry — even heartbeat, maintenance, or automated sessions with no user interaction. If nothing notable happened, write it: `- 09:00 — heartbeat ran, no user interactions, no new content`. No session ends with zero log entries.
+- **Minimum entry rule (non-negotiable):** Every session must create at least one log entry — even heartbeat, maintenance, triage, health-check, or automated sessions with no user interaction. Write the entry **before** any action that could fail or time out — if the session crashes, the log still has value. If nothing notable happened: `- 09:00 — heartbeat ran, no user interactions, no new content` or `- 09:00 — WF triage ran, 0 failures`. No session ends with zero log entries.
 - **Append continuously, not at the end.** If the session ends abruptly (crash, context compaction, timeout), the log still has value because you wrote as you went.
 - **Don't batch-decide "what was important."** If you're unsure whether an entry is worth it, write it — removing noise is cheap during consolidation, reconstructing lost context is not.
 - **One line per entry is fine.** Brief is better than nothing.
@@ -65,6 +65,8 @@ Rules:
 ```markdown
 # 2026-03-17
 
+- 09:00 — WF triage ran, 2 failures (erpio-gw login, rekap-dev deploy), created WF-123
+- 09:15 — check-triage ran, 0 failures, all systems OK
 - 14:30 — Learned that Alice prefers email over Slack for approvals
 - 14:45 — Fixed the deploy script; root cause was missing AWS region
 - 15:10 — User corrected: reports should go to #general, not #reports


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** daily-log-weekly-coverage
**Eval date:** 2026-04-18
**Overall score:** 0.9766

### Recent Eval History
- actionable-recommendations: 100%
- assess-memory-quality: 100%
- at-imports-configured: 100%
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 80%
- daily-log-exists-today: 81%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 30% <-- TARGET
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 100%
- meaningful-decisions: 100%
- no-data-loss: 100%
- previous-recommendations-reviewed: 94%
- process-self-critique: 100%
- reduce-log-count: 64%
- summary-md-regenerated: 100%
- today-md-archived: 100%
- update-relevant-tiers: 86%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** daily-log-weekly-coverage
**Files modified:** skills/memory/skill.md

### What changed

Strengthened the minimum entry rule in the Daily Logging section to:
1. Explicitly name `triage` and `health-check` sessions alongside heartbeat/maintenance/automated
2. Add guidance to write the log entry **before** any action that could fail or time out
3. Add concrete triage session examples (`WF triage ran, 2 failures...` / `check-triage ran, 0 failures`) to the example code block

### Report Insights Influence

Multiple consolidation reports identified the same root cause: "Daily log coverage at 57% is a persistent structural issue — triage scheduled commands don't write to daily logs." Two reports explicitly recommended: "KB change needed: add log-writing step to bot-check-triage and bot-wf-triage skill definitions." Since those channel-brain skills are out of scope, the base-brain memory skill was strengthened instead to make the rule unambiguous for all scheduled/triage invocations.

### Skill Impact

**Skill:** memory — always-active memory management skill governing all sessions
**Behavior change:** Triage and health-check sessions are now explicitly named in the non-negotiable minimum entry rule, with worked examples showing what a triage log entry looks like. The "write before action" instruction prevents log loss when sessions time out or fail mid-run.

### Expected impact

Agents running triage and health-check sessions will now see an explicit requirement with concrete examples, closing the structural gap that produced 57% coverage. Coverage should reach ≥80% (the passing threshold for daily-log-weekly-coverage) as triage sessions begin writing one-liner summaries to `memory/TODAY.md`.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*