### PR TITLE
fix: allow send_message to post top-level from thread session

### DIFF
--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -60,7 +60,7 @@ const TOOLS = [
         text: { type: 'string', description: 'Message text (supports Slack markdown: *bold*, _italic_, `code`, ```code blocks```, > quotes). Also used as fallback for blocks.' },
         blocks: { type: 'array', description: 'Optional Block Kit blocks array (e.g. sections, actions with buttons). See https://api.slack.com/block-kit', items: { type: 'object' } },
         channel: { type: 'string', description: 'Channel ID (default: current channel)' },
-        thread_ts: { type: 'string', description: 'Thread timestamp (default: current thread)' },
+        thread_ts: { type: 'string', description: 'Thread timestamp (default: current thread). Pass empty string to send a top-level channel message even when in a thread session.' },
         modals: {
           type: 'array',
           description: 'Modal form definitions to attach as buttons. Each opens a Slack modal when clicked.',
@@ -201,7 +201,8 @@ async function handleTool(name, args) {
   switch (name) {
     case 'send_message': {
       const channel = args.channel || DEFAULT_CHANNEL
-      const thread_ts = args.thread_ts || DEFAULT_THREAD_TS
+      // Allow explicit opt-out of thread context: thread_ts="" → top-level message
+      const thread_ts = args.thread_ts !== undefined ? (args.thread_ts || null) : DEFAULT_THREAD_TS
       if (!channel) throw new Error('channel required')
 
       let blocks = args.blocks ? [...args.blocks] : []

--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -202,7 +202,7 @@ async function handleTool(name, args) {
     case 'send_message': {
       const channel = args.channel || DEFAULT_CHANNEL
       // Allow explicit opt-out of thread context: thread_ts=null → top-level message
-      const thread_ts = args.thread_ts !== undefined ? (args.thread_ts || null) : DEFAULT_THREAD_TS
+      const thread_ts = args.thread_ts === undefined ? DEFAULT_THREAD_TS : args.thread_ts
       if (!channel) throw new Error('channel required')
 
       let blocks = args.blocks ? [...args.blocks] : []

--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -60,7 +60,7 @@ const TOOLS = [
         text: { type: 'string', description: 'Message text (supports Slack markdown: *bold*, _italic_, `code`, ```code blocks```, > quotes). Also used as fallback for blocks.' },
         blocks: { type: 'array', description: 'Optional Block Kit blocks array (e.g. sections, actions with buttons). See https://api.slack.com/block-kit', items: { type: 'object' } },
         channel: { type: 'string', description: 'Channel ID (default: current channel)' },
-        thread_ts: { type: 'string', description: 'Thread timestamp (default: current thread). Pass empty string to send a top-level channel message even when in a thread session.' },
+        thread_ts: { type: ['string', 'null'], description: 'Thread timestamp (default: current thread). Pass null to send a top-level channel message even when in a thread session.' },
         modals: {
           type: 'array',
           description: 'Modal form definitions to attach as buttons. Each opens a Slack modal when clicked.',
@@ -201,7 +201,7 @@ async function handleTool(name, args) {
   switch (name) {
     case 'send_message': {
       const channel = args.channel || DEFAULT_CHANNEL
-      // Allow explicit opt-out of thread context: thread_ts="" → top-level message
+      // Allow explicit opt-out of thread context: thread_ts=null → top-level message
       const thread_ts = args.thread_ts !== undefined ? (args.thread_ts || null) : DEFAULT_THREAD_TS
       if (!channel) throw new Error('channel required')
 


### PR DESCRIPTION
## Summary

- Fixes the `send_message` fallback logic in `mcp/slack.mjs` so agents can send top-level channel messages even when in a thread session
- Changes `args.thread_ts || DEFAULT_THREAD_TS` to `args.thread_ts !== undefined ? (args.thread_ts || null) : DEFAULT_THREAD_TS`
- Passing `thread_ts: ""` now explicitly opts out of thread context → top-level message
- Updated tool description to document the new behavior
- Backward compatible — omitting `thread_ts` still defaults to current thread

## Fixes

Closes teamvibeai/teamvibe.ai#62

## Test plan

- [ ] Agent in thread session: `send_message({ text: "test" })` → still posts to thread (no regression)
- [ ] Agent in thread session: `send_message({ text: "test", thread_ts: "" })` → posts top-level
- [ ] Agent in thread session: `send_message({ text: "test", thread_ts: "specific_ts" })` → posts to specific thread
- [ ] Agent without thread context: `send_message({ text: "test" })` → posts top-level (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)