### PR TITLE
Add tilde formatting pitfall to Slack skill

### DIFF
--- a/skills/slack/skill.md
+++ b/skills/slack/skill.md
@@ -73,3 +73,7 @@ Use Slack markdown in messages:
 - `` `inline code` ``, ` ```code block``` `
 - `>` for blockquotes
 - `<@U123>` for user mentions
+
+### Pitfalls
+
+- **Tilde (`~`) means strikethrough** — Slack treats `~text~` as ~~strikethrough~~. If you use `~` for "approximately" (e.g., `~$330`), Slack may match it with another `~` later and strike through everything in between. Use `≈` or `cca` instead. Backtick-wrapping (`` `~$330` ``) also works but changes the visual style.


### PR DESCRIPTION
## Summary
- Adds a "Pitfalls" subsection to the Slack skill's Formatting section
- Documents that `~` triggers strikethrough in Slack mrkdwn and recommends using `≈` or `cca` for "approximately"
- Prevents agents from producing unreadable strikethrough text when using tilde before numbers

## Context
Reported by Jarvis — using `~0.61 shares SPOT (~$330)` resulted in everything between the two tildes being struck through. Slack mrkdwn has no escape mechanism for `~`.

## Test plan
- [ ] Verify the pitfall note renders correctly in the skill documentation
- [ ] Confirm agents pick up the guidance in their system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)