### PR TITLE
feat: mistake promotion pipeline

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -73,7 +73,28 @@ Route new/updated facts to appropriate locations:
 | Lessons | `memory/core/LEARNINGS.md` |
 | Mistakes | `memory/core/MISTAKES.md` |
 
-### 5. Regenerate SUMMARY.md
+### 5. Promote Mistakes
+
+Review `memory/core/MISTAKES.md` for entries ready to be promoted. For each entry with status `new`:
+
+1. **Determine the promotion path:**
+   - Is the mistake specific to a skill/tool? → Add a pitfall to the relevant `skills/*/skill.md` file (create a `## Pitfalls` section if needed)
+   - Is it a general operational rule? → Extract the lesson to `memory/core/LEARNINGS.md`
+   - Is it critical enough for automated prevention? → Create a guard (file check, validation step) and document it in `memory/procedural/`
+
+2. **Execute the promotion:**
+   - Write the promoted content to its destination
+   - Update the MISTAKES.md entry status to `promoted → {destination}`
+
+3. **Clean up previously promoted entries:**
+   - Remove entries that were marked `promoted` in the *previous* consolidation run (they've been visible for one cycle)
+   - Keep entries marked `promoted` during *this* run (so the promotion is visible next cycle)
+
+If MISTAKES.md has no entries or doesn't exist, skip this step.
+
+**Report tracking:** Add any promoted-to files to `filesChanged`. Add a summary of promotions (or "no mistakes to promote") to the markdown report.
+
+### 6. Regenerate SUMMARY.md
 
 **Always regenerate `memory/SUMMARY.md` on every consolidation run — this step is non-negotiable, even if no facts were promoted in steps 2–4.** A lightweight consolidation with zero promotions must still regenerate SUMMARY.md to ensure it reflects the current state of all memory tiers.
 
@@ -90,7 +111,7 @@ This replaces the old "Update MEMORY.md" step. SUMMARY.md is the new authoritati
 
 **Report tracking (required):** Add `memory/SUMMARY.md` to the JSON report's `filesChanged` array. Evaluators check `filesChanged` for `memory/SUMMARY.md` to verify this step ran. Omitting it fails the `summary-md-regenerated` criterion even when the file was correctly regenerated.
 
-### 6. Archive Old Daily Logs
+### 7. Archive Old Daily Logs
 
 For daily log files (format: `YYYY-MM-DD.md`) in `memory/daily/` that are older than 30 days:
 - **Delete them.** Their content has already been promoted to long-term memory in steps 2–4.
@@ -100,14 +121,14 @@ For daily log files (format: `YYYY-MM-DD.md`) in `memory/daily/` that are older 
 
 **Recent-log retention (non-negotiable):** NEVER delete `memory/daily/<today>.md` or `memory/daily/<yesterday>.md`, regardless of whether their contents have been promoted. Same-day and next-day sessions rely on these files to recover context. Promotion is not a reason to delete; deletion is only for files dated 30+ days ago.
 
-### 7. Update Timestamp
+### 8. Update Timestamp
 
 Write the current date to `memory/.last_consolidation`:
 ```
 YYYY-MM-DD
 ```
 
-### 8. Assess Daily Log Compliance
+### 9. Assess Daily Log Compliance
 
 Before self-critique, run observable checks on the daily log scratchpad and record the outcome in both reports.
 
@@ -135,7 +156,7 @@ If any check fails, do one of two things before finishing:
 
 Do not silently pass a failing check.
 
-### 9. Process Self-Critique
+### 10. Process Self-Critique
 
 Before writing the report, reflect on whether the maintenance process itself is working. This is **required** — the JSON report's `processImprovements` field must contain at least one `[self-critique]` entry per consolidation run.
 
@@ -159,14 +180,14 @@ Example entries:
 - `"[self-critique] The same team project facts are re-extracted each cycle because they're not being promoted to semantic memory"`
 - `"[self-critique] Consolidation is running but memory retrieval quality hasn't been validated — promoted facts may not be surfaced in practice"`
 
-### 10. Produce Report
+### 11. Produce Report
 
 Create both a markdown and JSON report:
 
-- **Markdown:** `reports/YYYY-MM-DD-memory-consolidation.md` (must include the `## Daily Log Compliance` section from Step 8)
-- **JSON:** `reports/YYYY-MM-DD-memory-consolidation.json` (must include `daily-log-*` keys in `selfAssessment` and the `[self-critique]` entry from Step 9 in `processImprovements`)
+- **Markdown:** `reports/YYYY-MM-DD-memory-consolidation.md` (must include the `## Daily Log Compliance` section from Step 9)
+- **JSON:** `reports/YYYY-MM-DD-memory-consolidation.json` (must include `daily-log-*` keys in `selfAssessment` and the `[self-critique]` entry from Step 10 in `processImprovements`)
 
-For `selfAssessment.reduce-log-count`: set to `true` if at least one daily log was actively processed this run — either (a) Step 6 deleted one or more log files, OR (b) Steps 2–4 extracted content from at least one log and produced at least one ADD or UPDATE action. Set to `false` if no logs were processed (e.g., no logs in range, all NOOP). **Always include daily log files whose content was extracted in `filesChanged`**, even if they were not deleted — listing source logs gives the evaluator the evidence of log file activity it needs to verify this criterion.
+For `selfAssessment.reduce-log-count`: set to `true` if at least one daily log was actively processed this run — either (a) Step 7 deleted one or more log files, OR (b) Steps 2–4 extracted content from at least one log and produced at least one ADD or UPDATE action. Set to `false` if no logs were processed (e.g., no logs in range, all NOOP). **Always include daily log files whose content was extracted in `filesChanged`**, even if they were not deleted — listing source logs gives the evaluator the evidence of log file activity it needs to verify this criterion.
 
 ## Scoring Guidance
 

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -87,6 +87,10 @@ During regular sessions (non-maintenance), you may write to these places:
 - Stated preferences ("I prefer...", "always do...") → `memory/core/PREFERENCES.md`
 - Lessons from failures or successes → `memory/core/LEARNINGS.md`
 
+> **MISTAKES.md is a staging area.** Entries don't stay there forever — during
+> consolidation, each mistake is reviewed and promoted to a permanent home.
+> See the consolidation skill for the promotion pipeline.
+
 ### 2. `memory/TODAY.md` — for daily log entries
 
 ALL observations, facts, events, and short notes go into the daily log. This includes:
@@ -171,7 +175,7 @@ When you learn something new, route it:
 
 | Signal | Destination | Example |
 |--------|------------|---------|
-| User corrects you | `core/MISTAKES.md` | "No, the API key goes in the header, not query param" |
+| User corrects you | `core/MISTAKES.md` (staging) | "No, the API key goes in the header, not query param" |
 | User states preference | `core/PREFERENCES.md` | "Always use bullet points in summaries" |
 | You discover something useful | `core/LEARNINGS.md` | "The staging DB resets every Sunday" |
 | Factual info about team/project | `TODAY.md` | "Alice is the frontend lead" |
@@ -179,6 +183,31 @@ When you learn something new, route it:
 | You figure out how to do something | `TODAY.md` | "Deploy requires SSO login first" |
 | Substantial reference material (brainstorming, deep-dive) | `semantic/{topic}.md` | 30-min architecture discussion → session capture |
 | Action items, follow-ups | `HEARTBEAT.md` | "Check if PR #42 is merged by Friday" |
+
+## Mistake Promotion Pipeline
+
+`memory/core/MISTAKES.md` is a **staging area**, not a permanent archive. When you make a mistake or get corrected, write it there immediately. During consolidation, each entry is reviewed and promoted to a permanent home:
+
+| Promotion path | When to use | Example |
+|---------------|-------------|---------|
+| **Skill pitfall** | Mistake is specific to a skill/tool and would benefit from contextual warning | Slack tilde rendering → add Pitfalls section to `skills/slack/skill.md` |
+| **LEARNINGS.md** | Mistake reveals a general operational rule | "Always tag the person you're replying to" → `core/LEARNINGS.md` |
+| **Hardcoded guard** | Mistake is critical enough to need automated prevention | Guard file check before consolidation → `memory/.last_consolidation` |
+
+### MISTAKES.md Entry Format
+
+Each entry should include enough context for promotion:
+
+```markdown
+## YYYY-MM-DD — short description
+
+**What happened:** one-liner describing the mistake
+**Root cause:** why it happened
+**Impact:** what went wrong as a result
+**Status:** new | promoted → {destination}
+```
+
+When an entry is promoted, update its status and leave it for one consolidation cycle so the promotion is visible, then remove it. This keeps MISTAKES.md small and active — it's a to-do list, not a journal.
 
 ## Searching Deeper Memory
 


### PR DESCRIPTION
## Summary

Adds a structured promotion pipeline for `memory/core/MISTAKES.md`:

- **MISTAKES.md as staging area** — mistakes are captured during regular sessions, then promoted during consolidation
- **Three promotion paths:** skill pitfalls, LEARNINGS.md (operational rules), or hardcoded guards (automated prevention)
- **Entry lifecycle:** new → promoted (visible 1 cycle) → removed — keeps MISTAKES.md small and active
- **New consolidation step (Step 5)** — reviews MISTAKES.md entries and executes promotions before SUMMARY.md regeneration

### Files changed
- `skills/memory/skill.md` — documents promotion pipeline concept, entry format, and routing table
- `skills/memory/consolidate/skill.md` — adds Step 5 (Promote Mistakes), renumbers subsequent steps

### Context
Proposed 2026-04-21 after Jakub shared "RekapAI Bot — Problém s učením z chyb" report. Addresses the problem of passive memory without forced checkpoints — mistakes now have an explicit, mechanical promotion workflow instead of relying on vague consolidation intuitions.

## Test plan
- [ ] Verify consolidation runs correctly with empty MISTAKES.md (skip step)
- [ ] Verify a new MISTAKES.md entry gets promoted to the correct destination
- [ ] Verify promoted entries are cleaned up after one cycle
- [ ] Check step numbering is consistent throughout the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)