### PR TITLE
Auto-improve: summary-md-regenerated

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -183,7 +183,7 @@ Example entries:
 ### 11. Produce Report
 
 **Pre-report `filesChanged` verification:** Before writing the report, confirm these required entries are in `filesChanged`:
-- `memory/SUMMARY.md` — mandatory every run (Step 5); add it now if missing
+- `memory/SUMMARY.md` — mandatory every run (Step 6). If missing from `filesChanged`: do NOT just add the filename — go back and execute Step 6 now, regenerate `memory/SUMMARY.md` from current memory state, then add it to `filesChanged`. Skipping Step 6 silently is not allowed.
 - `memory/TODAY.md` — mandatory every run (Step 0); add it now if missing
 - `memory/daily/YYYY-MM-DD.md` — the archived daily log (Step 0); add it now if missing
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** summary-md-regenerated
**Eval date:** 2026-04-25
**Overall score:** 0.9889

### Recent Eval History
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 100%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 84%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 100%
- meaningful-decisions: 100%
- no-data-loss: 100%
- no-summary-manual-edit: 100%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 95%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 86% <-- TARGET
- today-md-archived: 88%
- update-relevant-tiers: 100%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** summary-md-regenerated
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Strengthened the pre-report `filesChanged` verification in Step 11 of the consolidation skill. The previous instruction said `"mandatory every run (Step 5); add it now if missing"` — which had two problems:

1. Wrong step number: SUMMARY.md is regenerated in Step 6, not Step 5.
2. Passive instruction: "add it now if missing" could be interpreted as just appending the filename to `filesChanged` without actually regenerating the file — satisfying the tracking requirement without doing the underlying work (or more likely, causing the brain to skip regeneration silently).

The new instruction explicitly says: if `memory/SUMMARY.md` is missing from `filesChanged`, go back and execute Step 6, regenerate the file from current memory state, then add it. It makes clear that silently skipping Step 6 is not allowed.

### Report insights influence

One report observation (from consolidation in 01KK9J6S6600DE48H2YG8XDJD5) noted: "SUMMARY.md had three stale facts simultaneously... SUMMARY was not regenerated because those days' consolidation guards skipped (lightweight cycles)." This confirms the failure mode: lightweight cycles skip Step 6 and then Step 11's safety net doesn't force them back. The fix directly addresses this by making the safety net require actual regeneration rather than just filename tracking.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure run during maintenance heartbeats.
**Behavior change:** The pre-report safety check now explicitly requires the brain to return to Step 6 and actually regenerate `memory/SUMMARY.md` if it was skipped, rather than just appending the filename to `filesChanged`. This closes the loophole where lightweight consolidation cycles could skip SUMMARY.md regeneration without being caught.

### Expected impact

Consolidations that skip Step 6 (lightweight cycles with zero promotions) will now be forced to regenerate SUMMARY.md before finalizing the report. This should bring the `summary-md-regenerated` pass rate from ~89% toward 100%.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*