### PR TITLE
Auto-improve: summary-md-regenerated

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -183,7 +183,7 @@ Example entries:
 ### 11. Produce Report
 
 **Pre-report `filesChanged` verification:** Before writing the report, confirm these required entries are in `filesChanged`:
-- `memory/SUMMARY.md` — mandatory every run (Step 5); add it now if missing
+- `memory/SUMMARY.md` — mandatory every run (Step 6); if missing from `filesChanged`, Step 6 was either skipped or not tracked — regenerate SUMMARY.md now (even on lightweight or no-new-content runs) then add to `filesChanged`
 - `memory/TODAY.md` — mandatory every run (Step 0); add it now if missing
 - `memory/daily/YYYY-MM-DD.md` — the archived daily log (Step 0); add it now if missing
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** summary-md-regenerated
**Eval date:** 2026-04-26
**Overall score:** 0.984

### Recent Eval History
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 100%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 89%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 100%
- meaningful-decisions: 100%
- no-data-loss: 100%
- no-summary-manual-edit: 100%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 95%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 83% <-- TARGET
- today-md-archived: 88%
- update-relevant-tiers: 100%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** summary-md-regenerated
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Fixed an incorrect step reference in the Step 11 pre-report `filesChanged` verification. The entry for `memory/SUMMARY.md` previously said "(Step 5)" — but Step 5 is "Promote Mistakes". SUMMARY.md regeneration is Step 6. This typo could cause the brain to lose track of which step produced the SUMMARY.md entry.

More importantly, the phrasing was changed from the passive "add it now if missing" to an active instruction: "if missing from `filesChanged`, Step 6 was either skipped or not tracked — regenerate SUMMARY.md now (even on lightweight or no-new-content runs) then add to `filesChanged`". This makes clear that the brain must actually run Step 6 if it hasn't, rather than just patching the tracking array.

### Report insights influence

Report-insights.md (line 202) confirmed that SUMMARY.md was not regenerated in "lightweight cycles" where consolidation guards skipped. This aligns with the fix: the verification step now explicitly calls out lightweight/no-new-content runs as not exempt from Step 6.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure run during heartbeat maintenance

**Behavior change:** The pre-report verification step now correctly identifies Step 6 (not Step 5) as the SUMMARY.md source, and instructs the brain to execute the regeneration immediately if it was skipped — rather than just adding a phantom entry to `filesChanged`. This closes the gap where lightweight consolidation cycles silently omitted SUMMARY.md from `filesChanged`.

### Expected impact

The correction to the step reference and the strengthened fallback instruction should eliminate the ~20% of consolidation runs that currently miss `memory/SUMMARY.md` in `filesChanged`, raising the `summary-md-regenerated` pass rate from 80% toward 100%.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*