### PR TITLE
feat: add read_channel_info MCP tool

### DIFF
--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -128,6 +128,16 @@ const TOOLS = [
     },
   },
   {
+    name: 'read_channel_info',
+    description: 'Get channel metadata: name, topic, purpose/description, member count, and privacy status. Useful for understanding channel context at the start of a session.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        channel: { type: 'string', description: 'Channel ID (default: current channel)' },
+      },
+    },
+  },
+  {
     name: 'upload_snippet',
     description: 'Upload a code or text snippet to the thread. Use for long outputs, code blocks, logs, or structured data instead of pasting into a message.',
     inputSchema: {
@@ -339,6 +349,26 @@ async function handleTool(name, args) {
         reply_count: m.reply_count,
       }))
       return { ok: true, messages }
+    }
+
+    case 'read_channel_info': {
+      const channel = args.channel || DEFAULT_CHANNEL
+      if (!channel) throw new Error('channel required')
+      const result = await slackApi('conversations.info', { channel })
+      const ch = result.channel
+      return {
+        ok: true,
+        channel: {
+          id: ch.id,
+          name: ch.name,
+          topic: ch.topic?.value || '',
+          purpose: ch.purpose?.value || '',
+          num_members: ch.num_members,
+          is_private: ch.is_private,
+          is_archived: ch.is_archived,
+          created: ch.created,
+        },
+      }
     }
 
     case 'upload_snippet': {


### PR DESCRIPTION
## Summary
- Adds new `read_channel_info` MCP tool to `slack.mjs` that calls Slack's `conversations.info` API
- Returns channel metadata: name, topic, purpose/description, member count, privacy status, archive status, creation date
- Enables agents to understand channel context at session start (e.g., project name, client info from topic/description)

## Context
Discussion: Jakub asked Jarvis to read channel topic/description → Jarvis can't (no tool for it) → VibeKeeper analyzed and proposed this solution.

**Required OAuth scopes** (already added to Jarvis's manifest): `channels:read`, `groups:read`

## Phase 2 (follow-up)
- `set_channel_topic` / `set_channel_purpose` (write tools)
- `list_pins` (pinned items)
- Bookmarks support

## Test plan
- [ ] Jarvis tests `read_channel_info` on his channel after merge
- [ ] Verify topic and purpose fields are returned correctly
- [ ] Test on both public and private channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)