### PR TITLE
Add [REMEMBER] tag for explicit memory requests

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -43,9 +43,31 @@ If `memory/TODAY.md` doesn't exist, do NOT skip this step. Instead: create `memo
 Read all files in `memory/daily/` dated since the last consolidation date.
 If no `.last_consolidation` file exists, process the last 14 days of logs.
 
+### 1b. Process `[REMEMBER]` Tags (priority)
+
+**Before** extracting general facts, scan all daily logs from step 1 for lines containing `[REMEMBER]`. These are explicit memory requests from the user and must be promoted with **guaranteed priority** — they are never filtered by heuristics.
+
+For each `[REMEMBER]` entry:
+
+1. **Classify** the destination based on content:
+   - Preference / communication style / workflow → `memory/core/PREFERENCES.md`
+   - Lesson / factual discovery → `memory/core/LEARNINGS.md`
+   - Correction / mistake to avoid → `memory/core/MISTAKES.md`
+   - Team/project fact → `memory/semantic/{topic}.md`
+
+2. **Check for duplicates** — grep the target file for similar content. If a match exists:
+   - **UPDATE** the existing entry with any new detail
+   - If identical, **NOOP** (don't create duplicates)
+
+3. **Write** to the destination file.
+
+4. **Report tracking:** Add each promoted `[REMEMBER]` item to the markdown report under a `## [REMEMBER] Promotions` section, listing: original entry, destination file, action taken (ADD/UPDATE/NOOP).
+
+If no `[REMEMBER]` tags are found, skip this step and note "no [REMEMBER] tags found" in the report.
+
 ### 2. Extract Facts
 
-For each daily log, identify:
+For each daily log, identify (excluding already-processed `[REMEMBER]` entries):
 - **Recurring themes** — things mentioned multiple times across days
 - **Explicit corrections** — should already be in core/, verify they are
 - **New factual knowledge** — team info, project details, domain knowledge

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -169,12 +169,34 @@ Not all sections are required — use what fits the content.
 
 Use kebab-case, short, no prefixes: `stepforge.md`, `vest-liquidation.md`. If maintenance splits a file that exceeds ~100 lines, it adds a suffix: `stepforge-architecture.md`.
 
+## `[REMEMBER]` Tag — Explicit Memory Requests
+
+When a user explicitly asks you to remember something ("zapamatuj si", "remember this", "to si zapiš"), use the `[REMEMBER]` tag in TODAY.md:
+
+```markdown
+- [REMEMBER] komunikace: mužský rod, vždy česky
+- [REMEMBER] deploy: staging vyžaduje SSO login
+```
+
+**How it works:**
+1. Append a `[REMEMBER]` line to `memory/TODAY.md` — this is immediately in your context via `@` import
+2. Confirm to the user: what was saved, and that it will be promoted to permanent memory during next consolidation
+3. Consolidation will pick up `[REMEMBER]` tags with **guaranteed promotion** — they are never skipped or filtered by heuristics
+
+**When to use `[REMEMBER]`:**
+- User explicitly asks you to remember/save something
+- User states a strong preference or correction that must persist
+- Do NOT tag routine observations — those go as normal daily log entries
+
+**Format:** `- [REMEMBER] category: detail` — the category hint (e.g., "komunikace", "workflow", "deploy") helps consolidation route to the right destination, but is not required.
+
 ## Routing Logic
 
 When you learn something new, route it:
 
 | Signal | Destination | Example |
 |--------|------------|---------|
+| User explicitly asks to remember | `TODAY.md` with `[REMEMBER]` tag | "Zapamatuj si že jsem mužského rodu" |
 | User corrects you | `core/MISTAKES.md` (staging) | "No, the API key goes in the header, not query param" |
 | User states preference | `core/PREFERENCES.md` | "Always use bullet points in summaries" |
 | You discover something useful | `core/LEARNINGS.md` | "The staging DB resets every Sunday" |

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -180,7 +180,7 @@ When a user explicitly asks you to remember something ("zapamatuj si", "remember
 
 **How it works:**
 1. Append a `[REMEMBER]` line to `memory/TODAY.md` — this is immediately in your context via `@` import
-2. Confirm to the user: what was saved, and that it will be promoted to permanent memory during next consolidation
+2. Confirm to the user what was saved (e.g., "Zapsáno." / "Uloženo do paměti.")
 3. Consolidation will pick up `[REMEMBER]` tags with **guaranteed promotion** — they are never skipped or filtered by heuristics
 
 **When to use `[REMEMBER]`:**


### PR DESCRIPTION
## Summary

- Adds `[REMEMBER]` tag convention to the memory skill — agents write `- [REMEMBER] category: detail` to TODAY.md when users explicitly ask to remember something
- Extends consolidation skill with a new priority step (1b) that processes `[REMEMBER]` tags with **guaranteed promotion** — they are never filtered by heuristics
- Duplicate check: grep target file before writing (ADD vs UPDATE vs NOOP)

## Problem

Case study "Zapiš si mužský rod" showed that agents don't have a reliable, simple path for "user says remember X → X persists across sessions". The agent must decide where to write, whether to update SUMMARY.md, and what to tell the user. This is error-prone.

## Solution

Single entry point: `TODAY.md` with `[REMEMBER]` tag. Info is immediately in context (TODAY.md is `@`-imported). Consolidation picks it up and routes to the correct core file. No "Recent" section in SUMMARY.md needed — TODAY.md already provides immediate visibility.

Inspired by the hippocampal buffer model (neurological research): all new memories enter through one point, sorting happens during "sleep" (consolidation).

## Changes

1. **`skills/memory/skill.md`** — new `[REMEMBER]` tag section with usage rules + updated routing table
2. **`skills/memory/consolidate/skill.md`** — new Step 1b: priority processing of `[REMEMBER]` tags before general fact extraction

## Classification

**Tier 2** — changes agent behavior (new convention + consolidation logic). Needs Jakub's approval.

Addresses #54.

## Test plan

- [ ] Agent receives "zapamatuj si X" → writes `[REMEMBER]` line to TODAY.md
- [ ] Consolidation processes `[REMEMBER]` tag → promotes to correct core file
- [ ] Consolidation report shows `[REMEMBER] Promotions` section
- [ ] Duplicate `[REMEMBER]` entries → UPDATE, not duplicate ADD