### PR TITLE
Make core/ files read-only for regular sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,11 +102,11 @@ If these files don't exist yet, they'll be created during the next maintenance c
 **Daily log = your running scratchpad.** As you work, append one-liners to `memory/TODAY.md` whenever something is worth remembering tomorrow: a decision, a correction, a surprising finding, a completed task. Append *continuously* during the session — don't batch at the end, and don't skip because "nothing important happened yet." If the session involves tool use or a real exchange, it almost always produces at least one line worth keeping.
 
 **Where to write (regular sessions):**
-- Corrections → `memory/core/MISTAKES.md`
-- Preferences → `memory/core/PREFERENCES.md`
-- Lessons learned → `memory/core/LEARNINGS.md`
-- Daily log entries → `memory/TODAY.md`
+- ALL new information → `memory/TODAY.md` (the single entry point)
+- Important items (corrections, preferences, lessons) → `memory/TODAY.md` with `[REMEMBER]` tag
 - Session capture (brainstorming, deep-dive) → `memory/semantic/{topic}.md` (see memory skill for full pattern)
+
+**NEVER write directly to `memory/core/`** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Use `[REMEMBER]` tags in TODAY.md instead.
 
 **NEVER self-promote during regular sessions** — don't reorganize old logs into `semantic/`, `episodic/`, or `procedural/`. That's maintenance's job. Writing *new content from the current conversation* to `semantic/` (session capture) is allowed. See the **Session Capture** section in the memory skill for rules.
 

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -125,12 +125,14 @@ Read all `memory/core/*.md`, scan `memory/semantic/`, `memory/episodic/`, `memor
 Key sections:
 - **How this memory works** — static block explaining what's in context vs. what requires lookup (copy verbatim from the template in the memory skill)
 - **Identity** — who you are (from channel brain CLAUDE.md)
-- **Key Rules** — compressed top rules from MISTAKES.md + LEARNINGS.md
-- **Preferences** — compressed from PREFERENCES.md
+- **Key Rules** — actionable rules from LEARNINGS.md, each with a pointer to the source file for detail (e.g., "Always verify live data before trade proposals (detail: core/LEARNINGS.md)")
+- **Preferences** — actionable preferences from PREFERENCES.md with pointer to source file
 - **Active Projects** — from recent episodic/ entries
 - **Deep Memory Index** — pointers to all memory tiers with topic summaries
 
 The "How this memory works" block MUST be the first section in SUMMARY.md. It is static content — do not rephrase or compress it, copy it from the template.
+
+**Key Rules and Preferences must be actionable, not just labels.** Bad: "stale prices". Good: "Always verify live data before trade proposals (detail: core/LEARNINGS.md)". The pointer tells the agent where to find the full context if needed.
 
 This replaces the old "Update MEMORY.md" step. SUMMARY.md is the new authoritative index.
 

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -81,29 +81,22 @@ Rules:
 
 During regular sessions (non-maintenance), you may write to these places:
 
-### 1. `memory/core/` — for high-signal corrections and preferences
+### 1. `memory/TODAY.md` — primary write target
 
-- Explicit corrections ("no, do it this way") → `memory/core/MISTAKES.md`
-- Stated preferences ("I prefer...", "always do...") → `memory/core/PREFERENCES.md`
-- Lessons from failures or successes → `memory/core/LEARNINGS.md`
-
-> **MISTAKES.md is a staging area.** Entries don't stay there forever — during
-> consolidation, each mistake is reviewed and promoted to a permanent home.
-> See the consolidation skill for the promotion pipeline.
-
-### 2. `memory/TODAY.md` — for daily log entries
-
-ALL observations, facts, events, and short notes go into the daily log. This includes:
+ALL new information goes into the daily log. This includes:
 - Factual info about the team or project (e.g., "Alice is the frontend lead")
 - Notable events (e.g., "production went down for 2h")
 - Workflows and procedures you figured out
 - Task progress, conversation notes, routine observations
+- Corrections, preferences, and lessons — use the `[REMEMBER]` tag (see below)
 
-### 3. `memory/semantic/` — for session capture (see below)
+### 2. `memory/semantic/` — for session capture (see below)
 
 When a session produces substantial content (brainstorming, deep-dive, design discussion), you may write directly to `memory/semantic/{topic}.md`. See the **Session Capture** section for rules.
 
 ### What is NOT allowed
+
+**Do NOT write directly to `memory/core/` files** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Write to `memory/TODAY.md` instead — use the `[REMEMBER]` tag for important items that must be promoted.
 
 **Do NOT self-promote content during regular sessions.** Self-promotion means reading old daily logs or existing memory and reorganizing them into `semantic/`, `episodic/`, or `procedural/`. That is maintenance's job — only the consolidation process curates and reorganizes existing content.
 
@@ -197,9 +190,9 @@ When you learn something new, route it:
 | Signal | Destination | Example |
 |--------|------------|---------|
 | User explicitly asks to remember | `TODAY.md` with `[REMEMBER]` tag | "Zapamatuj si že jsem mužského rodu" |
-| User corrects you | `core/MISTAKES.md` (staging) | "No, the API key goes in the header, not query param" |
-| User states preference | `core/PREFERENCES.md` | "Always use bullet points in summaries" |
-| You discover something useful | `core/LEARNINGS.md` | "The staging DB resets every Sunday" |
+| User corrects you | `TODAY.md` with `[REMEMBER]` tag | "No, the API key goes in the header, not query param" |
+| User states preference | `TODAY.md` with `[REMEMBER]` tag | "Always use bullet points in summaries" |
+| You discover something useful | `TODAY.md` with `[REMEMBER]` tag | "The staging DB resets every Sunday" |
 | Factual info about team/project | `TODAY.md` | "Alice is the frontend lead" |
 | Something notable happened | `TODAY.md` | "Production went down for 2h due to DNS" |
 | You figure out how to do something | `TODAY.md` | "Deploy requires SSO login first" |
@@ -254,11 +247,12 @@ Structure:
 ## Identity
 - [who you are, 1-2 lines]
 
-## Key Rules (from core/MISTAKES.md + core/LEARNINGS.md)
-- [top 10-15 operational rules, compressed]
+## Key Rules (from core/LEARNINGS.md)
+- [top 10-15 operational rules, actionable — include pointer to source file for detail]
+- example: "Always verify live data before trade proposals (detail: core/LEARNINGS.md)"
 
 ## Preferences (from core/PREFERENCES.md)
-- [key preferences, compressed]
+- [key preferences, actionable — include pointer to source file for detail]
 
 ## Active Projects (from episodic/)
 - [current work in progress, 5-10 lines]


### PR DESCRIPTION
## Summary

- `memory/core/` files (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) are now **read-only during regular sessions**
- TODAY.md becomes the single entry point for all new information — corrections, preferences, and lessons use `[REMEMBER]` tags
- Consolidation handles all routing from TODAY.md to core/ files
- SUMMARY.md entries now include pointers to source files for full context

## Problem

After merging #56 (`[REMEMBER]` tag), we had an inconsistent dual-path: some writes went to TODAY.md, some directly to core/ files. This meant agents had to decide *where* to write (error-prone) and info written to core/ wasn't in context until consolidation ran (same gap as the original case study).

## Changes

1. **`CLAUDE.md`** — "Where to write" section updated: all new info → TODAY.md, `[REMEMBER]` for important items, explicit "NEVER write directly to core/" rule
2. **`skills/memory/skill.md`** — "Where to Write" section simplified (removed core/ as write target), routing table updated (corrections/preferences/lessons now go via `[REMEMBER]` tag), SUMMARY.md format updated with pointer guidance
3. **`skills/memory/consolidate/skill.md`** — Step 6 updated: Key Rules and Preferences entries must be actionable with pointers to source files

## Classification

**Tier 2** — changes agent write behavior (core/ becomes read-only for regular sessions). Needs Jakub's approval.

Addresses #54.

## Test plan

- [ ] Agent receiving "ne, dělej to takhle" writes `[REMEMBER]` to TODAY.md, not directly to MISTAKES.md
- [ ] Consolidation generates SUMMARY.md with actionable rules including source file pointers
- [ ] Agent correctly refuses to write to core/ during regular session