### PR TITLE
fix: consolidation verbatim archival, auto-memory warning, nighttime window

### DIFF
--- a/scripts/maintenance-guard.sh
+++ b/scripts/maintenance-guard.sh
@@ -1,13 +1,45 @@
 #!/bin/bash
 # Checks if maintenance consolidation should run.
-# Exit 0 = consolidation needed, exit 1 = skip (ran recently).
+# Exit 0 = consolidation needed, exit 1 = skip (not time yet).
 # Usage: bash scripts/maintenance-guard.sh [brain_dir]
 #
 # brain_dir defaults to current working directory.
+#
+# Consolidation ("dreaming") should run during quiet hours to avoid
+# disrupting active user sessions. Mid-day consolidation can cause the
+# bot to "forget" things the user said minutes ago (TODAY.md gets archived
+# and reset). Nighttime runs are more natural — like sleep-based memory
+# consolidation.
+#
+# Policy:
+# - Preferred window: 00:00–06:00 UTC (configurable via CONSOLIDATION_WINDOW_START/END)
+# - If 24h+ since last run AND inside the window → run
+# - If 48h+ since last run → run regardless of time (safety fallback)
+# - If <24h since last run → skip
 
 BRAIN_DIR="${1:-.}"
 GUARD_FILE="$BRAIN_DIR/memory/.last_consolidation"
 INTERVAL_HOURS=24
+FALLBACK_HOURS=48
+WINDOW_START="${CONSOLIDATION_WINDOW_START:-0}"   # hour UTC (inclusive)
+WINDOW_END="${CONSOLIDATION_WINDOW_END:-6}"       # hour UTC (exclusive)
+
+# Get current UTC hour
+CURRENT_HOUR=$(date -u +%H | sed 's/^0//')
+if [ -z "$CURRENT_HOUR" ]; then
+  CURRENT_HOUR=0
+fi
+
+# Check if we're inside the preferred consolidation window
+in_window() {
+  if [ "$WINDOW_START" -lt "$WINDOW_END" ]; then
+    # Normal range (e.g., 0-6)
+    [ "$CURRENT_HOUR" -ge "$WINDOW_START" ] && [ "$CURRENT_HOUR" -lt "$WINDOW_END" ]
+  else
+    # Wrapping range (e.g., 22-6)
+    [ "$CURRENT_HOUR" -ge "$WINDOW_START" ] || [ "$CURRENT_HOUR" -lt "$WINDOW_END" ]
+  fi
+}
 
 if [ ! -f "$GUARD_FILE" ]; then
   echo "consolidation_needed: true (no guard file found)"
@@ -36,10 +68,23 @@ fi
 NOW_EPOCH=$(date +%s)
 ELAPSED_HOURS=$(( (NOW_EPOCH - LAST_EPOCH) / 3600 ))
 
+# Case 1: Ran recently — always skip
 if [ "$ELAPSED_HOURS" -lt "$INTERVAL_HOURS" ]; then
   echo "consolidation_needed: false (last ran ${ELAPSED_HOURS}h ago, threshold ${INTERVAL_HOURS}h)"
   exit 1
 fi
 
-echo "consolidation_needed: true (last ran ${ELAPSED_HOURS}h ago, threshold ${INTERVAL_HOURS}h)"
-exit 0
+# Case 2: Overdue (48h+) — run regardless of time window (safety fallback)
+if [ "$ELAPSED_HOURS" -ge "$FALLBACK_HOURS" ]; then
+  echo "consolidation_needed: true (overdue — last ran ${ELAPSED_HOURS}h ago, fallback threshold ${FALLBACK_HOURS}h, running outside window)"
+  exit 0
+fi
+
+# Case 3: Due (24h+) — only run inside the preferred window
+if in_window; then
+  echo "consolidation_needed: true (last ran ${ELAPSED_HOURS}h ago, inside window ${WINDOW_START}:00-${WINDOW_END}:00 UTC)"
+  exit 0
+else
+  echo "consolidation_needed: false (last ran ${ELAPSED_HOURS}h ago, outside window ${WINDOW_START}:00-${WINDOW_END}:00 UTC, current hour ${CURRENT_HOUR} UTC)"
+  exit 1
+fi

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -23,7 +23,7 @@ Before processing, archive `memory/TODAY.md` to the daily/ directory:
 
 1. Read `memory/TODAY.md` — extract the date header(s) (format: `# YYYY-MM-DD`)
 2. For each date section in TODAY.md:
-   - Append its content to `memory/daily/YYYY-MM-DD.md` (create if needed)
+   - Append its content **verbatim** to `memory/daily/YYYY-MM-DD.md` (create if needed). Copy every bullet point and line exactly as written — do NOT summarize, truncate, rephrase, or condense entries. The daily archive must be a byte-for-byte copy of the original content.
 3. Reset `memory/TODAY.md` with today's date header and an immediate consolidation log entry:
    ```
    # YYYY-MM-DD
@@ -46,6 +46,9 @@ If no `.last_consolidation` file exists, process the last 14 days of logs.
 ### 1b. Process `[MEM-NNN]` Tracked Keys (priority)
 
 **Before** extracting general facts, scan all daily logs from step 1 for lines containing `[MEM-\d+]`, `[MEM-<word>]` (malformed), or `[REMEMBER]` (backward compat). These are tracked memory entries and must be promoted with **guaranteed priority** — they are never filtered by heuristics.
+
+> **⚠️ Anti-pattern: auto-memory is NOT persistent memory.**
+> Claude Code's built-in auto-memory (`~/.claude/projects/.../memory/`) is ephemeral — it does not survive re-clones, machine changes, or container restarts. NEVER treat auto-memory as a substitute for writing to the brain's `memory/` tier files. `[MEM-NNN]` items MUST be physically written to `memory/core/` or `memory/semantic/` files. Claiming "already captured in auto-memory" is NOT valid — auto-memory is provider-specific and not part of our memory model.
 
 #### Auto-fix malformed keys
 
@@ -83,7 +86,9 @@ If a `[REMEMBER]` tag is found (without a `[MEM-NNN]` key):
    - [MEM-3] Deploy flow: main = STAGING only, produkce = version tag (v0.0.X)...
    ```
 
-5. **Report tracking:** Add each promoted `[MEM-NNN]` item to the markdown report under a `## [MEM] Promotions` section, listing: key, original entry, destination file, action taken (ADD/UPDATE/NOOP).
+5. **Verify promotion landed** — after writing, grep the target file for a key phrase from the promoted entry. If the grep returns no match, the write failed — retry or flag as an error in the report. Do not proceed to the next item until verification passes.
+
+6. **Report tracking:** Add each promoted `[MEM-NNN]` item to the markdown report under a `## [MEM] Promotions` section, listing: key, original entry, destination file, action taken (ADD/UPDATE/NOOP), verification result (VERIFIED/FAILED).
 
 If no `[MEM-NNN]` or `[REMEMBER]` tags are found, skip this step and note "no [MEM] tags found" in the report.
 


### PR DESCRIPTION
## Summary

Three fixes for memory consolidation reliability, prompted by data loss observed in infodental bot's consolidation run ([commit `6cf998e`](https://github.com/infodentalcz/infodental-kb/commit/6cf998edc18151fc3e6e410a3aafe1ed84361900)).

- **Step 0 — verbatim archival:** Added explicit "do NOT summarize, truncate, or rephrase" language. The bot interpreted "append its content" as "append a summary", losing granular details (DynamoDB table names, Jira states, milestones)
- **Step 1b — auto-memory anti-pattern:** Added warning that Claude Code auto-memory is ephemeral and must never substitute for writing to brain `memory/` tiers. Added post-write verification step (grep target file to confirm promotion landed). Bot had claimed "[REMEMBER] items already captured in auto-memory" — but auto-memory doesn't persist across sessions/machines
- **Guard script — nighttime window:** Consolidation now prefers 00:00–06:00 UTC (configurable via env vars). Mid-day consolidation made the bot "forget" things said minutes earlier. Safety fallback: if 48h+ overdue, runs regardless of time window

## Files changed

| File | Change |
|------|--------|
| `skills/memory/consolidate/skill.md` | Verbatim archival + auto-memory warning + verification step |
| `scripts/maintenance-guard.sh` | Nighttime window (00-06 UTC) + 48h fallback |

Closes #63

## Test plan

- [ ] Verify guard script correctly blocks consolidation outside 00-06 UTC window
- [ ] Verify guard script allows consolidation when 48h+ overdue regardless of time
- [ ] Verify guard script handles wrapping window ranges (e.g., 22-06)
- [ ] Manually run consolidation on a test brain and confirm TODAY.md entries are copied verbatim to daily/
- [ ] Confirm [REMEMBER] items are promoted to core/ files with verification grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)