### PR TITLE
fix: clarify MEM key format — must be sequential numbers, not words

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,10 @@ If these files don't exist yet, they'll be created during the next maintenance c
 
 **Where to write (regular sessions):**
 - ALL new information → `memory/TODAY.md` (the single entry point)
-- Important items (corrections, preferences, lessons) → `memory/TODAY.md` with `[MEM-xxx]` tracked key (see memory skill)
+- Important items (corrections, preferences, lessons) → `memory/TODAY.md` with `[MEM-NNN]` tracked key (see memory skill)
 - Session capture (brainstorming, deep-dive) → `memory/semantic/{topic}.md` (see memory skill for full pattern)
 
-**NEVER write directly to `memory/core/`** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Use `[MEM-xxx]` tracked keys in TODAY.md instead (see memory skill for format).
+**NEVER write directly to `memory/core/`** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Use `[MEM-NNN]` tracked keys in TODAY.md instead (see memory skill for format).
 
 **NEVER self-promote during regular sessions** — don't reorganize old logs into `semantic/`, `episodic/`, or `procedural/`. That's maintenance's job. Writing *new content from the current conversation* to `semantic/` (session capture) is allowed. See the **Session Capture** section in the memory skill for rules.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,10 @@ If these files don't exist yet, they'll be created during the next maintenance c
 
 **Where to write (regular sessions):**
 - ALL new information → `memory/TODAY.md` (the single entry point)
-- Important items (corrections, preferences, lessons) → `memory/TODAY.md` with `[MEM-NNN]` tracked key (see memory skill)
+- Important items (corrections, preferences, lessons) → run `npx tsx .claude/skills/memory/scripts/mem-write.ts "category: detail"` (never write `[MEM-NNN]` tags manually)
 - Session capture (brainstorming, deep-dive) → `memory/semantic/{topic}.md` (see memory skill for full pattern)
 
-**NEVER write directly to `memory/core/`** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Use `[MEM-NNN]` tracked keys in TODAY.md instead (see memory skill for format).
+**NEVER write directly to `memory/core/`** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Use `npx tsx .claude/skills/memory/scripts/mem-write.ts` to create tracked memory entries (see memory skill).
 
 **NEVER self-promote during regular sessions** — don't reorganize old logs into `semantic/`, `episodic/`, or `procedural/`. That's maintenance's job. Writing *new content from the current conversation* to `semantic/` (session capture) is allowed. See the **Session Capture** section in the memory skill for rules.
 

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -45,7 +45,16 @@ If no `.last_consolidation` file exists, process the last 14 days of logs.
 
 ### 1b. Process `[MEM-NNN]` Tracked Keys (priority)
 
-**Before** extracting general facts, scan all daily logs from step 1 for lines containing `[MEM-\d+]` or `[REMEMBER]` (backward compat). These are tracked memory entries and must be promoted with **guaranteed priority** — they are never filtered by heuristics.
+**Before** extracting general facts, scan all daily logs from step 1 for lines containing `[MEM-\d+]`, `[MEM-<word>]` (malformed), or `[REMEMBER]` (backward compat). These are tracked memory entries and must be promoted with **guaranteed priority** — they are never filtered by heuristics.
+
+#### Auto-fix malformed keys
+
+If a `[MEM-<word>]` tag is found where `<word>` is NOT a number (e.g., `[MEM-feedback]`, `[MEM-TAG]`):
+1. Assign the next available sequential number (read `memory/MEM_REGISTRY.md`, find highest number, increment)
+2. Replace the malformed tag in the daily log with the correct `[MEM-N]` format
+3. Add the corrected key to the registry with status `ACTIVE`
+4. Log the fix in the report: "Auto-fixed malformed key: [MEM-feedback] → [MEM-4]"
+5. Process as a normal `[MEM-NNN]` entry
 
 #### Handling `[REMEMBER]` backward compatibility
 
@@ -71,7 +80,7 @@ If a `[REMEMBER]` tag is found (without a `[MEM-NNN]` key):
 4. **Write** to the destination file. The `[MEM-NNN]` key MUST be preserved in the promoted entry:
    ```markdown
    # In core/LEARNINGS.md:
-   - [MEM-003] Deploy flow: main = STAGING only, produkce = version tag (v0.0.X)...
+   - [MEM-3] Deploy flow: main = STAGING only, produkce = version tag (v0.0.X)...
    ```
 
 5. **Report tracking:** Add each promoted `[MEM-NNN]` item to the markdown report under a `## [MEM] Promotions` section, listing: key, original entry, destination file, action taken (ADD/UPDATE/NOOP).

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -43,18 +43,18 @@ If `memory/TODAY.md` doesn't exist, do NOT skip this step. Instead: create `memo
 Read all files in `memory/daily/` dated since the last consolidation date.
 If no `.last_consolidation` file exists, process the last 14 days of logs.
 
-### 1b. Process `[MEM-xxx]` Keys (priority)
+### 1b. Process `[MEM-NNN]` Tracked Keys (priority)
 
 **Before** extracting general facts, scan all daily logs from step 1 for lines containing `[MEM-\d+]` or `[REMEMBER]` (backward compat). These are tracked memory entries and must be promoted with **guaranteed priority** — they are never filtered by heuristics.
 
 #### Handling `[REMEMBER]` backward compatibility
 
-If a `[REMEMBER]` tag is found (without a `[MEM-xxx]` key):
+If a `[REMEMBER]` tag is found (without a `[MEM-NNN]` key):
 1. Assign the next available key (read `memory/MEM_REGISTRY.md`, find highest number, increment)
 2. Add the new key to the registry with status `ACTIVE`
-3. Process as if it were a `[MEM-xxx]` entry
+3. Process as if it were a `[MEM-NNN]` entry
 
-#### For each `[MEM-xxx]` entry:
+#### For each `[MEM-NNN]` entry:
 
 1. **Check the registry** — if the key isn't in `memory/MEM_REGISTRY.md` yet (new entry from a regular session), add it with status `ACTIVE`, today's date, and a short description.
 
@@ -64,19 +64,19 @@ If a `[REMEMBER]` tag is found (without a `[MEM-xxx]` key):
    - Correction / mistake to avoid → `memory/core/MISTAKES.md`
    - Team/project fact → `memory/semantic/{topic}.md`
 
-3. **Check for duplicates** — grep the target file for the same `[MEM-xxx]` key or similar content. If a match exists:
-   - **UPDATE** the existing entry with any new detail (preserve the `[MEM-xxx]` key)
+3. **Check for duplicates** — grep the target file for the same `[MEM-NNN]` key or similar content. If a match exists:
+   - **UPDATE** the existing entry with any new detail (preserve the `[MEM-NNN]` key)
    - If identical, **NOOP** (don't create duplicates)
 
-4. **Write** to the destination file. The `[MEM-xxx]` key MUST be preserved in the promoted entry:
+4. **Write** to the destination file. The `[MEM-NNN]` key MUST be preserved in the promoted entry:
    ```markdown
    # In core/LEARNINGS.md:
    - [MEM-003] Deploy flow: main = STAGING only, produkce = version tag (v0.0.X)...
    ```
 
-5. **Report tracking:** Add each promoted `[MEM-xxx]` item to the markdown report under a `## [MEM] Promotions` section, listing: key, original entry, destination file, action taken (ADD/UPDATE/NOOP).
+5. **Report tracking:** Add each promoted `[MEM-NNN]` item to the markdown report under a `## [MEM] Promotions` section, listing: key, original entry, destination file, action taken (ADD/UPDATE/NOOP).
 
-If no `[MEM-xxx]` or `[REMEMBER]` tags are found, skip this step and note "no [MEM] tags found" in the report.
+If no `[MEM-NNN]` or `[REMEMBER]` tags are found, skip this step and note "no [MEM] tags found" in the report.
 
 ### 1c. MEM Lifecycle — Obsolescence Check
 
@@ -84,7 +84,7 @@ Review entries in `memory/MEM_REGISTRY.md` with status `ACTIVE`:
 
 1. **Check for contradictions** — if newer daily log entries contradict or supersede an existing ACTIVE entry, mark it `OBSOLETE`:
    - Update registry: status → `OBSOLETE`, set obsoleted date
-   - Update the content file: change `[MEM-xxx]` to `[MEM-xxx:obsolete]`
+   - Update the content file: change `[MEM-NNN]` to `[MEM-xxx:obsolete]`
    - The entry stays in the content file for one consolidation cycle
 
 2. **Process previously OBSOLETE entries** — for entries marked `OBSOLETE` in a *previous* consolidation run (check git history or the obsoleted date vs. last consolidation date):
@@ -96,7 +96,7 @@ Review entries in `memory/MEM_REGISTRY.md` with status `ACTIVE`:
 
 ### 2. Extract Facts
 
-For each daily log, identify (excluding already-processed `[MEM-xxx]` / `[REMEMBER]` entries):
+For each daily log, identify (excluding already-processed `[MEM-NNN]` / `[REMEMBER]` entries):
 - **Recurring themes** — things mentioned multiple times across days
 - **Explicit corrections** — should already be in core/, verify they are
 - **New factual knowledge** — team info, project details, domain knowledge
@@ -314,7 +314,7 @@ Example entries:
 - `memory/SUMMARY.md` — mandatory every run (Step 6). If missing from `filesChanged`: do NOT just add the filename — go back and execute Step 6 now, regenerate `memory/SUMMARY.md` from current memory state, then add it to `filesChanged`. Skipping Step 6 silently is not allowed.
 - `memory/TODAY.md` — mandatory every run (Step 0); add it now if missing
 - `memory/daily/YYYY-MM-DD.md` — the archived daily log (Step 0); add it now if missing
-- `memory/MEM_REGISTRY.md` — if any `[MEM-xxx]` entries were processed or lifecycle changes made in steps 1b/1c; add it now if missing
+- `memory/MEM_REGISTRY.md` — if any `[MEM-NNN]` entries were processed or lifecycle changes made in steps 1b/1c; add it now if missing
 
 Create both a markdown and JSON report:
 

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -93,7 +93,7 @@ Review entries in `memory/MEM_REGISTRY.md` with status `ACTIVE`:
 
 1. **Check for contradictions** — if newer daily log entries contradict or supersede an existing ACTIVE entry, mark it `OBSOLETE`:
    - Update registry: status → `OBSOLETE`, set obsoleted date
-   - Update the content file: change `[MEM-NNN]` to `[MEM-xxx:obsolete]`
+   - Update the content file: change `[MEM-N]` to `[MEM-N:obsolete]`
    - The entry stays in the content file for one consolidation cycle
 
 2. **Process previously OBSOLETE entries** — for entries marked `OBSOLETE` in a *previous* consolidation run (check git history or the obsoleted date vs. last consolidation date):

--- a/skills/memory/scripts/mem-write.ts
+++ b/skills/memory/scripts/mem-write.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env npx tsx
+/**
+ * Create a new tracked MEM key entry.
+ *
+ * Atomically writes to both memory/TODAY.md and memory/MEM_REGISTRY.md
+ * with the next sequential number. Prevents malformed keys like [MEM-feedback].
+ *
+ * Usage:
+ *   npx tsx mem-write.ts "category: detail"
+ *   npx tsx mem-write.ts "deploy: staging vyžaduje SSO login"
+ *   npx tsx mem-write.ts "komunikace: mužský rod, vždy česky"
+ *
+ * Output:
+ *   Written [MEM-4] to memory/TODAY.md and memory/MEM_REGISTRY.md
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const REGISTRY_PATH = "memory/MEM_REGISTRY.md";
+const TODAY_PATH = "memory/TODAY.md";
+
+const REGISTRY_HEADER = `# MEM Registry
+
+| Key | Status | Created | Obsoleted | Description |
+|-----|--------|---------|-----------|-------------|
+`;
+
+function getNextKey(): number {
+  if (!fs.existsSync(REGISTRY_PATH)) {
+    return 1;
+  }
+  const content = fs.readFileSync(REGISTRY_PATH, "utf-8");
+  const matches = content.matchAll(/MEM-(\d+)/g);
+  let max = 0;
+  for (const m of matches) {
+    const n = parseInt(m[1], 10);
+    if (n > max) max = n;
+  }
+  return max + 1;
+}
+
+function ensureRegistry(): void {
+  if (!fs.existsSync(REGISTRY_PATH)) {
+    fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
+    fs.writeFileSync(REGISTRY_PATH, REGISTRY_HEADER);
+  }
+}
+
+function ensureToday(): void {
+  if (!fs.existsSync(TODAY_PATH)) {
+    fs.mkdirSync(path.dirname(TODAY_PATH), { recursive: true });
+    const today = new Date().toISOString().slice(0, 10);
+    fs.writeFileSync(TODAY_PATH, `# ${today}\n\n`);
+  }
+}
+
+function getToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function main(): void {
+  const content = process.argv.slice(2).join(" ").trim();
+
+  if (!content) {
+    console.error("Usage: npx tsx mem-write.ts \"category: detail\"");
+    console.error("");
+    console.error("Examples:");
+    console.error('  npx tsx mem-write.ts "deploy: staging vyžaduje SSO login"');
+    console.error('  npx tsx mem-write.ts "komunikace: mužský rod, vždy česky"');
+    process.exit(1);
+  }
+
+  ensureRegistry();
+  ensureToday();
+
+  const key = getNextKey();
+  const today = getToday();
+
+  // Short description for registry (first 60 chars)
+  const desc = content.length > 60 ? content.slice(0, 57) + "..." : content;
+
+  // Append to TODAY.md
+  fs.appendFileSync(TODAY_PATH, `- [MEM-${key}] ${content}\n`);
+
+  // Append to MEM_REGISTRY.md
+  fs.appendFileSync(
+    REGISTRY_PATH,
+    `| MEM-${key} | ACTIVE | ${today} | — | ${desc} |\n`
+  );
+
+  console.log(`Written [MEM-${key}] to ${TODAY_PATH} and ${REGISTRY_PATH}`);
+}
+
+main();

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -216,37 +216,29 @@ Critical information gets a unique, tracked key — like Jira tickets for memory
 
 ### How to write a `[MEM-NNN]` entry
 
-**Do NOT pick the number yourself.** Run these bash commands — they determine the next key deterministically:
+**Do NOT pick the number yourself.** Use the `mem-write` script — it handles numbering, TODAY.md, and MEM_REGISTRY.md atomically:
 
 ```bash
-# Step 1: Get next key number
-LAST=$(grep -oP 'MEM-\K\d+' memory/MEM_REGISTRY.md 2>/dev/null | sort -n | tail -1)
-NEXT=$(( ${LAST:-0} + 1 ))
-echo "Next MEM key: MEM-$NEXT"
+npx tsx .claude/skills/memory/scripts/mem-write.ts "category: detail"
 ```
 
-Then use the printed key to write both files:
-
+**Examples:**
 ```bash
-# Step 2: Write to TODAY.md (replace CONTENT with actual text)
-echo "- [MEM-$NEXT] CONTENT" >> memory/TODAY.md
-
-# Step 3: Write to MEM_REGISTRY.md (replace DESC with short description)
-echo "| MEM-$NEXT | ACTIVE | $(date +%Y-%m-%d) | — | DESC |" >> memory/MEM_REGISTRY.md
+npx tsx .claude/skills/memory/scripts/mem-write.ts "deploy: staging vyžaduje SSO login"
+npx tsx .claude/skills/memory/scripts/mem-write.ts "komunikace: mužský rod, vždy česky"
+# Output: Written [MEM-4] to memory/TODAY.md and memory/MEM_REGISTRY.md
 ```
 
-If `memory/MEM_REGISTRY.md` doesn't exist yet, create it first with the header:
+The script:
+1. Reads `memory/MEM_REGISTRY.md`, finds the highest existing number
+2. Increments to get the next key
+3. Appends `- [MEM-N] content` to `memory/TODAY.md`
+4. Appends a registry row to `memory/MEM_REGISTRY.md`
+5. Creates both files with correct headers if they don't exist yet
 
-```bash
-cat > memory/MEM_REGISTRY.md << 'HEADER'
-# MEM Registry
+**NEVER write `[MEM-NNN]` entries manually** — always use the script. This prevents malformed keys like `[MEM-feedback]`.
 
-| Key | Status | Created | Obsoleted | Description |
-|-----|--------|---------|-----------|-------------|
-HEADER
-```
-
-After writing, confirm to user: "Zapsáno." / "Uloženo do paměti." (don't mention internal mechanics)
+After the script runs, confirm to user: "Zapsáno." / "Uloženo do paměti." (don't mention internal mechanics)
 
 **Example result:**
 ```markdown

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -197,11 +197,11 @@ Use kebab-case, short, no prefixes: `stepforge.md`, `vest-liquidation.md`. If ma
 
 Critical information gets a unique, tracked key — like Jira tickets for memory. Keys survive consolidation, are traceable via grep and git history, and have an explicit lifecycle that prevents silent data loss.
 
-**IMPORTANT: Keys are ALWAYS sequential numbers, never words.** The key format is `MEM-` followed by a zero-padded 3-digit number: `MEM-001`, `MEM-002`, `MEM-003`, etc.
+**IMPORTANT: Keys are ALWAYS sequential numbers, never words.** The key format is `MEM-` followed by a number: `MEM-1`, `MEM-2`, `MEM-3`, etc. No zero-padding needed.
 
 ```
-✅ Correct:  [MEM-001] deploy: staging vyžaduje SSO
-✅ Correct:  [MEM-042] komunikace: mužský rod
+✅ Correct:  [MEM-1] deploy: staging vyžaduje SSO
+✅ Correct:  [MEM-42] komunikace: mužský rod
 ❌ WRONG:   [MEM-feedback] ...     ← NOT a number!
 ❌ WRONG:   [MEM-TAG] ...          ← NOT a number!
 ❌ WRONG:   [MEM-deploy] ...       ← NOT a number!
@@ -216,19 +216,47 @@ Critical information gets a unique, tracked key — like Jira tickets for memory
 
 ### How to write a `[MEM-NNN]` entry
 
-1. **Get the next key:** grep for the highest existing `MEM-\d+` in `memory/MEM_REGISTRY.md`. Increment by 1, zero-pad to 3 digits. If the registry doesn't exist or is empty, start at `MEM-001`.
-2. **Write to TODAY.md:** `- [MEM-001] category: detail` (use the actual next number, not a placeholder)
-3. **Add to registry:** Append a row to `memory/MEM_REGISTRY.md` (create the file if needed)
-4. **Confirm to user:** "Zapsáno." / "Uloženo do paměti." (don't mention internal mechanics)
+**Do NOT pick the number yourself.** Run these bash commands — they determine the next key deterministically:
 
+```bash
+# Step 1: Get next key number
+LAST=$(grep -oP 'MEM-\K\d+' memory/MEM_REGISTRY.md 2>/dev/null | sort -n | tail -1)
+NEXT=$(( ${LAST:-0} + 1 ))
+echo "Next MEM key: MEM-$NEXT"
+```
+
+Then use the printed key to write both files:
+
+```bash
+# Step 2: Write to TODAY.md (replace CONTENT with actual text)
+echo "- [MEM-$NEXT] CONTENT" >> memory/TODAY.md
+
+# Step 3: Write to MEM_REGISTRY.md (replace DESC with short description)
+echo "| MEM-$NEXT | ACTIVE | $(date +%Y-%m-%d) | — | DESC |" >> memory/MEM_REGISTRY.md
+```
+
+If `memory/MEM_REGISTRY.md` doesn't exist yet, create it first with the header:
+
+```bash
+cat > memory/MEM_REGISTRY.md << 'HEADER'
+# MEM Registry
+
+| Key | Status | Created | Obsoleted | Description |
+|-----|--------|---------|-----------|-------------|
+HEADER
+```
+
+After writing, confirm to user: "Zapsáno." / "Uloženo do paměti." (don't mention internal mechanics)
+
+**Example result:**
 ```markdown
 # In TODAY.md:
-- [MEM-003] deploy: staging vyžaduje SSO login
-- [MEM-004] komunikace: mužský rod, vždy česky
+- [MEM-3] deploy: staging vyžaduje SSO login
+- [MEM-4] komunikace: mužský rod, vždy česky
 
 # In MEM_REGISTRY.md:
-| MEM-003 | ACTIVE | 2026-04-28 | — | Staging deploy requires SSO login |
-| MEM-004 | ACTIVE | 2026-04-28 | — | Communication: masculine, always Czech |
+| MEM-3 | ACTIVE | 2026-04-28 | — | Staging deploy requires SSO login |
+| MEM-4 | ACTIVE | 2026-04-28 | — | Communication: masculine, always Czech |
 ```
 
 ### MEM_REGISTRY.md Format
@@ -240,13 +268,13 @@ This file is the **source of truth** for all tracked memory keys. It lives at `m
 
 | Key | Status | Created | Obsoleted | Description |
 |-----|--------|---------|-----------|-------------|
-| MEM-001 | ACTIVE | 2026-04-28 | — | Auto-memory is ephemeral, never rely on it |
-| MEM-002 | OBSOLETE | 2026-04-15 | 2026-04-28 | Old deploy flow (superseded by MEM-003) |
-| MEM-003 | ACTIVE | 2026-04-28 | — | Staging deploy requires SSO login |
+| MEM-1 | ACTIVE | 2026-04-28 | — | Auto-memory is ephemeral, never rely on it |
+| MEM-2 | OBSOLETE | 2026-04-15 | 2026-04-28 | Old deploy flow (superseded by MEM-3) |
+| MEM-3 | ACTIVE | 2026-04-28 | — | Staging deploy requires SSO login |
 ```
 
 **Columns:**
-- **Key** — unique identifier, sequential per brain (`MEM-001`, `MEM-002`, ...)
+- **Key** — unique identifier, sequential per brain (`MEM-1`, `MEM-2`, ...)
 - **Status** — `ACTIVE`, `OBSOLETE`, or `REMOVED`
 - **Created** — date the entry was first written
 - **Obsoleted** — date the entry was marked obsolete (or `—` if active)
@@ -258,13 +286,13 @@ This file is the **source of truth** for all tracked memory keys. It lives at `m
 ACTIVE → OBSOLETE → REMOVED
 ```
 
-1. **ACTIVE** — the memory is current and must be preserved during consolidation. Tag in content files: `[MEM-NNN]` (e.g. `[MEM-003]`)
-2. **OBSOLETE** — the memory is outdated or superseded. Marked during consolidation with reason + date. Tag in content files changes to `[MEM-NNN:obsolete]` (e.g. `[MEM-003:obsolete]`). The entry stays in its promoted location for one consolidation cycle.
+1. **ACTIVE** — the memory is current and must be preserved during consolidation. Tag in content files: `[MEM-3]`
+2. **OBSOLETE** — the memory is outdated or superseded. Marked during consolidation with reason + date. Tag in content files changes to `[MEM-3:obsolete]`. The entry stays in its promoted location for one consolidation cycle.
 3. **REMOVED** — the entry is deleted from content files on the next consolidation after being marked OBSOLETE. Registry row remains (with REMOVED status) for audit trail — never delete registry rows.
 
 **Rules:**
 - A `[MEM-NNN]` entry must **never** be deleted from content files without first going through `OBSOLETE` status
-- Keys persist through promotion: if `[MEM-003]` starts in TODAY.md and gets promoted to `LEARNINGS.md`, the key `[MEM-003]` stays in the promoted entry
+- Keys persist through promotion: if `[MEM-3]` starts in TODAY.md and gets promoted to `LEARNINGS.md`, the key `[MEM-3]` stays in the promoted entry
 - Consolidation must verify all ACTIVE keys from the registry exist somewhere in `memory/` — a missing ACTIVE key is an integrity violation
 - Sequential gaps in key numbers are acceptable (from REMOVED entries) but must match the registry — an unexpected gap signals data loss
 

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -290,7 +290,7 @@ ACTIVE → OBSOLETE → REMOVED
 
 ### Backward Compatibility
 
-The `[REMEMBER]` tag continues to work as an alias — consolidation will auto-assign the next available sequential number to any `[REMEMBER]` entry found in daily logs and register it. New entries should always use `[MEM-NNN]` with a real number (e.g., `[MEM-001]`).
+The `[REMEMBER]` tag continues to work as an alias — consolidation will auto-assign the next available sequential number to any `[REMEMBER]` entry found in daily logs and register it. New entries should always use the `mem-write.ts` script (e.g., result: `[MEM-1]`).
 
 ## Routing Logic
 

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -89,7 +89,7 @@ ALL new information goes into the daily log. This includes:
 - Notable events (e.g., "production went down for 2h")
 - Workflows and procedures you figured out
 - Task progress, conversation notes, routine observations
-- Corrections, preferences, and lessons — use `[MEM-xxx]` tracked keys (see below)
+- Corrections, preferences, and lessons — use `[MEM-NNN]` tracked keys (see below)
 
 ### 2. `memory/semantic/` — for larger content (pointer pattern)
 
@@ -124,7 +124,7 @@ This pattern also applies to **session capture** — see the section below for d
 
 ### What is NOT allowed
 
-**Do NOT write directly to `memory/core/` files** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Write to `memory/TODAY.md` instead — use `[MEM-xxx]` keys for important items that must be promoted.
+**Do NOT write directly to `memory/core/` files** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Write to `memory/TODAY.md` instead — use `[MEM-NNN]` keys for important items that must be promoted.
 
 **Do NOT self-promote content during regular sessions.** Self-promotion means reading old daily logs or existing memory and reorganizing them into `semantic/`, `episodic/`, or `procedural/`. That is maintenance's job — only the consolidation process curates and reorganizes existing content.
 
@@ -193,21 +193,31 @@ Not all sections are required — use what fits the content.
 
 Use kebab-case, short, no prefixes: `stepforge.md`, `vest-liquidation.md`. If maintenance splits a file that exceeds ~100 lines, it adds a suffix: `stepforge-architecture.md`.
 
-## `[MEM-xxx]` — Tracked Memory Keys
+## `[MEM-NNN]` — Tracked Memory Keys
 
 Critical information gets a unique, tracked key — like Jira tickets for memory. Keys survive consolidation, are traceable via grep and git history, and have an explicit lifecycle that prevents silent data loss.
 
-### When to create a `[MEM-xxx]` entry
+**IMPORTANT: Keys are ALWAYS sequential numbers, never words.** The key format is `MEM-` followed by a zero-padded 3-digit number: `MEM-001`, `MEM-002`, `MEM-003`, etc.
+
+```
+✅ Correct:  [MEM-001] deploy: staging vyžaduje SSO
+✅ Correct:  [MEM-042] komunikace: mužský rod
+❌ WRONG:   [MEM-feedback] ...     ← NOT a number!
+❌ WRONG:   [MEM-TAG] ...          ← NOT a number!
+❌ WRONG:   [MEM-deploy] ...       ← NOT a number!
+```
+
+### When to create a `[MEM-NNN]` entry
 
 - User explicitly asks you to remember/save something ("zapamatuj si", "remember this")
 - User states a strong preference or correction that must persist
 - You discover something critical that must not be lost
 - Do NOT tag routine observations — those go as normal daily log entries
 
-### How to write a `[MEM-xxx]` entry
+### How to write a `[MEM-NNN]` entry
 
 1. **Get the next key:** grep for the highest existing `MEM-\d+` in `memory/MEM_REGISTRY.md`. Increment by 1, zero-pad to 3 digits. If the registry doesn't exist or is empty, start at `MEM-001`.
-2. **Write to TODAY.md:** `- [MEM-xxx] category: detail`
+2. **Write to TODAY.md:** `- [MEM-001] category: detail` (use the actual next number, not a placeholder)
 3. **Add to registry:** Append a row to `memory/MEM_REGISTRY.md` (create the file if needed)
 4. **Confirm to user:** "Zapsáno." / "Uloženo do paměti." (don't mention internal mechanics)
 
@@ -248,19 +258,19 @@ This file is the **source of truth** for all tracked memory keys. It lives at `m
 ACTIVE → OBSOLETE → REMOVED
 ```
 
-1. **ACTIVE** — the memory is current and must be preserved during consolidation. Tag in content files: `[MEM-xxx]`
-2. **OBSOLETE** — the memory is outdated or superseded. Marked during consolidation with reason + date. Tag in content files changes to `[MEM-xxx:obsolete]`. The entry stays in its promoted location for one consolidation cycle.
+1. **ACTIVE** — the memory is current and must be preserved during consolidation. Tag in content files: `[MEM-NNN]` (e.g. `[MEM-003]`)
+2. **OBSOLETE** — the memory is outdated or superseded. Marked during consolidation with reason + date. Tag in content files changes to `[MEM-NNN:obsolete]` (e.g. `[MEM-003:obsolete]`). The entry stays in its promoted location for one consolidation cycle.
 3. **REMOVED** — the entry is deleted from content files on the next consolidation after being marked OBSOLETE. Registry row remains (with REMOVED status) for audit trail — never delete registry rows.
 
 **Rules:**
-- A `[MEM-xxx]` entry must **never** be deleted from content files without first going through `OBSOLETE` status
+- A `[MEM-NNN]` entry must **never** be deleted from content files without first going through `OBSOLETE` status
 - Keys persist through promotion: if `[MEM-003]` starts in TODAY.md and gets promoted to `LEARNINGS.md`, the key `[MEM-003]` stays in the promoted entry
 - Consolidation must verify all ACTIVE keys from the registry exist somewhere in `memory/` — a missing ACTIVE key is an integrity violation
 - Sequential gaps in key numbers are acceptable (from REMOVED entries) but must match the registry — an unexpected gap signals data loss
 
 ### Backward Compatibility
 
-The `[REMEMBER]` tag continues to work as an alias for `[MEM-xxx]` — consolidation will auto-assign the next available key to any `[REMEMBER]` entry found in daily logs and register it. New entries should always use `[MEM-xxx]`.
+The `[REMEMBER]` tag continues to work as an alias — consolidation will auto-assign the next available sequential number to any `[REMEMBER]` entry found in daily logs and register it. New entries should always use `[MEM-NNN]` with a real number (e.g., `[MEM-001]`).
 
 ## Routing Logic
 
@@ -268,10 +278,10 @@ When you learn something new, route it:
 
 | Signal | Destination | Example |
 |--------|------------|---------|
-| User explicitly asks to remember | `TODAY.md` with `[MEM-xxx]` key | "Zapamatuj si že jsem mužského rodu" |
-| User corrects you | `TODAY.md` with `[MEM-xxx]` key | "No, the API key goes in the header, not query param" |
-| User states preference | `TODAY.md` with `[MEM-xxx]` key | "Always use bullet points in summaries" |
-| You discover something useful | `TODAY.md` with `[MEM-xxx]` key | "The staging DB resets every Sunday" |
+| User explicitly asks to remember | `TODAY.md` with `[MEM-NNN]` key | "Zapamatuj si že jsem mužského rodu" |
+| User corrects you | `TODAY.md` with `[MEM-NNN]` key | "No, the API key goes in the header, not query param" |
+| User states preference | `TODAY.md` with `[MEM-NNN]` key | "Always use bullet points in summaries" |
+| You discover something useful | `TODAY.md` with `[MEM-NNN]` key | "The staging DB resets every Sunday" |
 | Factual info about team/project | `TODAY.md` | "Alice is the frontend lead" |
 | Something notable happened | `TODAY.md` | "Production went down for 2h due to DNS" |
 | You figure out how to do something | `TODAY.md` | "Deploy requires SSO login first" |


### PR DESCRIPTION
## Summary

Agents were writing `[MEM-feedback]`, `[MEM-TAG]` instead of `[MEM-001]`, `[MEM-002]`. The placeholder notation `[MEM-xxx]` was ambiguous — agents interpreted `xxx` as a descriptive word rather than a number.

**Fix:**
- Rename `[MEM-xxx]` → `[MEM-NNN]` throughout all docs (memory skill, consolidation skill, CLAUDE.md)
- Add bold warning: "Keys are ALWAYS sequential numbers, never words"
- Add explicit ✅/❌ examples at the top of the section

This is a Tier 1 documentation fix — no behavior change, just clarification.

## Test plan

- [ ] Grep for any remaining `[MEM-xxx]` references
- [ ] Verify the ✅/❌ examples are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)