### PR TITLE
Auto-improve: today-md-archived

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -326,8 +326,8 @@ Example entries:
 
 **Pre-report `filesChanged` verification:** Before writing the report, confirm these required entries are in `filesChanged`:
 - `memory/SUMMARY.md` — mandatory every run (Step 6). If missing from `filesChanged`: do NOT just add the filename — go back and execute Step 6 now, regenerate `memory/SUMMARY.md` from current memory state, then add it to `filesChanged`. Skipping Step 6 silently is not allowed.
-- `memory/TODAY.md` — mandatory every run (Step 0); add it now if missing
-- `memory/daily/YYYY-MM-DD.md` — the archived daily log (Step 0); add it now if missing
+- `memory/TODAY.md` — mandatory every run (Step 0). If missing from `filesChanged`: do NOT just add the filename — go back and execute Step 0 now (reset TODAY.md with today's header and a consolidation start entry if not already done, append any existing content to today's daily log), then add `memory/TODAY.md` to `filesChanged`. Skipping Step 0 silently is not allowed.
+- `memory/daily/YYYY-MM-DD.md` — the archived daily log (Step 0); add it now if missing (omit only when TODAY.md did not exist prior to this run)
 - `memory/MEM_REGISTRY.md` — if any `[MEM-NNN]` entries were processed or lifecycle changes made in steps 1b/1c; add it now if missing
 
 Create both a markdown and JSON report:


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** today-md-archived
**Eval date:** 2026-04-28
**Overall score:** 0.99

### Recent Eval History
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 100%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 96%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 100%
- meaningful-decisions: 100%
- no-data-loss: 100%
- no-summary-manual-edit: 98%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 95%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 86%
- today-md-archived: 91% <-- TARGET
- update-relevant-tiers: 100%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** today-md-archived
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Strengthened the Step 12 pre-report `filesChanged` verification for `memory/TODAY.md` to match the same explicit "do NOT just add the filename — go back and execute Step 0 now" guard already present for `memory/SUMMARY.md`.

Before: `memory/TODAY.md — mandatory every run (Step 0); add it now if missing`

After: `memory/TODAY.md — mandatory every run (Step 0). If missing from filesChanged: do NOT just add the filename — go back and execute Step 0 now (reset TODAY.md with today's header and a consolidation start entry if not already done, append any existing content to today's daily log), then add memory/TODAY.md to filesChanged. Skipping Step 0 silently is not allowed.`

Also clarified the `memory/daily/YYYY-MM-DD.md` line to note it can be omitted only when TODAY.md did not exist prior to the run (matching the existing Step 0 edge-case guidance).

### Why

The Step 12 pre-report check had an asymmetry: `memory/SUMMARY.md` included a strong "do NOT just add the filename — go back and execute Step 6 now" guard, while `memory/TODAY.md` only said "add it now if missing" — a weaker instruction that agents could interpret as merely appending the filename string to `filesChanged` without actually executing Step 0. Light consolidations (no new user-session content in TODAY.md) are the most likely trigger for this shortcut. The `summary-md-regenerated` criterion fails at the same rate (0.9444), consistent with a pattern where both steps are sometimes skipped in the same light-consolidation run.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure run during maintenance heartbeats.
**Behavior change:** In Step 12 (pre-report verification), when TODAY.md is missing from `filesChanged`, the skill now requires the agent to re-execute Step 0 (actually write to TODAY.md) rather than just inserting the filename. This eliminates the shortcut path where an agent could log TODAY.md in the report without having modified the file.

### Expected impact

The `today-md-archived` pass rate should improve from ~0.94 toward 1.0 by closing the loophole that allowed Step 0 to be silently skipped. The change is also consistent with report-insights observations noting that some brains produce light-pass consolidations with no meaningful activity — those are exactly the runs most likely to skip Step 0.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*