### PR TITLE
fix: use $CLAUDE_CONFIG_DIR for mem-write.ts path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,10 @@ If these files don't exist yet, they'll be created during the next maintenance c
 
 **Where to write (regular sessions):**
 - ALL new information → `memory/TODAY.md` (the single entry point)
-- Important items (corrections, preferences, lessons) → run `npx tsx .claude/skills/memory/scripts/mem-write.ts "category: detail"` (never write `[MEM-NNN]` tags manually)
+- Important items (corrections, preferences, lessons) → run `npx tsx $CLAUDE_CONFIG_DIR/skills/memory/scripts/mem-write.ts "category: detail"` (never write `[MEM-NNN]` tags manually)
 - Session capture (brainstorming, deep-dive) → `memory/semantic/{topic}.md` (see memory skill for full pattern)
 
-**NEVER write directly to `memory/core/`** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Use `npx tsx .claude/skills/memory/scripts/mem-write.ts` to create tracked memory entries (see memory skill).
+**NEVER write directly to `memory/core/`** (MISTAKES.md, PREFERENCES.md, LEARNINGS.md) during regular sessions. These files are managed exclusively by consolidation. Use `npx tsx $CLAUDE_CONFIG_DIR/skills/memory/scripts/mem-write.ts` to create tracked memory entries (see memory skill).
 
 **NEVER self-promote during regular sessions** — don't reorganize old logs into `semantic/`, `episodic/`, or `procedural/`. That's maintenance's job. Writing *new content from the current conversation* to `semantic/` (session capture) is allowed. See the **Session Capture** section in the memory skill for rules.
 

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -219,13 +219,13 @@ Critical information gets a unique, tracked key — like Jira tickets for memory
 **Do NOT pick the number yourself.** Use the `mem-write` script — it handles numbering, TODAY.md, and MEM_REGISTRY.md atomically:
 
 ```bash
-npx tsx .claude/skills/memory/scripts/mem-write.ts "category: detail"
+npx tsx $CLAUDE_CONFIG_DIR/skills/memory/scripts/mem-write.ts "category: detail"
 ```
 
 **Examples:**
 ```bash
-npx tsx .claude/skills/memory/scripts/mem-write.ts "deploy: staging vyžaduje SSO login"
-npx tsx .claude/skills/memory/scripts/mem-write.ts "komunikace: mužský rod, vždy česky"
+npx tsx $CLAUDE_CONFIG_DIR/skills/memory/scripts/mem-write.ts "deploy: staging vyžaduje SSO login"
+npx tsx $CLAUDE_CONFIG_DIR/skills/memory/scripts/mem-write.ts "komunikace: mužský rod, vždy česky"
 # Output: Written [MEM-4] to memory/TODAY.md and memory/MEM_REGISTRY.md
 ```
 


### PR DESCRIPTION
## Summary
- Base-brain skills live at `$CLAUDE_CONFIG_DIR/skills/`, not `.claude/skills/` in the channel brain
- The `.claude/skills/` path caused `ERR_MODULE_NOT_FOUND` for all agents trying to use `mem-write.ts`
- Updated all 5 occurrences in CLAUDE.md (2) and skill.md (3)

**Tier 1** — straightforward path fix, no logic changes.

Found by @jarvis-bot during testing of PR #67.

## Test plan
- [ ] Agent runs `npx tsx "$CLAUDE_CONFIG_DIR/skills/memory/scripts/mem-write.ts" "test"` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)