### PR TITLE
Auto-improve: summary-md-regenerated

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -17,6 +17,8 @@ If it's 1+ days old or missing, run consolidation.
 
 ## Algorithm
 
+**All steps below are mandatory on every consolidation run.** There is no "lightweight" or "partial" mode. Even when daily logs are empty or steps 2–4 produce zero promotions, Step 6 (Regenerate SUMMARY.md) MUST still execute. Never skip or abbreviate steps because a run "has nothing to process."
+
 ### 0. Archive TODAY.md
 
 Before processing, archive `memory/TODAY.md` to the daily/ directory:


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** summary-md-regenerated
**Eval date:** 2026-04-29
**Overall score:** 0.997

### Recent Eval History
- actionable-recommendations: 100%
- assess-memory-quality: 100%
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 100%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 100%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 100%
- meaningful-decisions: 100%
- no-data-loss: 100%
- no-summary-manual-edit: 98%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 100%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 90% <-- TARGET
- today-md-archived: 93%
- update-relevant-tiers: 100%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** summary-md-regenerated
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Added an explicit "all steps mandatory" notice at the top of the Algorithm section in the consolidation skill, making it unambiguous that there is no "lightweight" or "partial" consolidation mode. The notice specifically calls out Step 6 (Regenerate SUMMARY.md) as mandatory even when steps 2–4 produce zero promotions.

### Why

The historical pass rate is ~90%, meaning roughly 1 in 10 consolidation runs omits `memory/SUMMARY.md` from `filesChanged`. Report insights confirmed the failure pattern: "SUMMARY was not regenerated because those days' consolidation guards skipped (lightweight cycles)." Brains were treating some runs as light passes and skipping Step 6. The skill already had strong language in Step 6 and Step 12, but adding the notice at the very top of the Algorithm section prevents the brain from deciding to abbreviate the run before it even reaches those steps.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure run during maintenance heartbeats
**Behavior change:** The skill now begins its Algorithm section with an explicit statement that all steps are mandatory on every run. This prevents brains from entering a "lightweight mode" and skipping SUMMARY.md regeneration, ensuring `memory/SUMMARY.md` always appears in `filesChanged`.

### Expected impact

Consolidation runs that previously produced a report without `memory/SUMMARY.md` in `filesChanged` should now reliably include it, improving the `summary-md-regenerated` pass rate from the historical ~90% toward 100%.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*