### PR TITLE
feat: gradual CLAUDE.md reduction in consolidation

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -268,12 +268,13 @@ If the Memory Metrics table (Step 9b) shows `CLAUDE.md` exceeding 10000 bytes, p
 
 2. **Extract it:**
    - Create the target file (or append to an existing one) with the extracted content
-   - Replace the block in `CLAUDE.md` with a one-line markdown pointer, e.g.: `- **Topic detail:** viz memory/procedural/{topic}.md`
-   - The pointer stays visible in CLAUDE.md so the agent (and humans) can find the extracted content
+   - Remove the block from `CLAUDE.md` entirely — do NOT leave a pointer in CLAUDE.md (saves space)
+   - Instead, ensure `memory/SUMMARY.md` references the new file so the agent can find it via the always-loaded `@` import
 
 3. **Log it** in the markdown report under `## CLAUDE.md Reduction`:
    - What was moved, from where to where, size delta
    - Why this block was chosen (procedural/reference/duplicate)
+   - Confirm the SUMMARY.md pointer was added
 
 4. **Constraints:**
    - Move *at most 1 block per cycle* — gradual reduction, not a big-bang refactor

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -257,6 +257,32 @@ Measure sizes of key memory files and include a `## Memory Metrics` section in t
 - `LEARNINGS.md` > 5000 — risk: too many rules to follow
 - `MEM_REGISTRY.md` > 5000 — risk: registry too large (archive REMOVED entries)
 
+#### 9c. CLAUDE.md Gradual Reduction
+
+If the Memory Metrics table (Step 9b) shows `CLAUDE.md` exceeding 10000 bytes, perform **one** small extraction per consolidation cycle:
+
+1. **Identify one block** (10–30 lines) in `CLAUDE.md` that is procedural, reference-like, or domain-specific knowledge — not core identity or behavioral rules. Good candidates:
+   - Step-by-step workflows → move to `memory/procedural/{topic}.md`
+   - Domain knowledge / data structures → move to `memory/semantic/{topic}.md`
+   - Rules that duplicate base-brain CLAUDE.md or `@`-imported SUMMARY.md → delete
+
+2. **Extract it:**
+   - Create the target file (or append to an existing one) with the extracted content
+   - Replace the block in `CLAUDE.md` with a one-line pointer: `<!-- Detail: memory/procedural/{topic}.md -->`
+   - The pointer is a comment — it won't render but helps trace where content went
+
+3. **Log it** in the markdown report under `## CLAUDE.md Reduction`:
+   - What was moved, from where to where, size delta
+   - Why this block was chosen (procedural/reference/duplicate)
+
+4. **Constraints:**
+   - Move *at most 1 block per cycle* — gradual reduction, not a big-bang refactor
+   - *Never move* identity sections, `@` import lines, or core behavioral rules
+   - If unsure whether a block is safe to move, skip this step and note "no safe candidate found" in the report
+   - If `CLAUDE.md` is under 10000 bytes, skip this step entirely
+
+This ensures steady progress toward the threshold while allowing time to detect regressions between cycles.
+
 ### 10. Assess Daily Log Compliance
 
 Before self-critique, run observable checks on the daily log scratchpad and record the outcome in both reports.

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -268,8 +268,8 @@ If the Memory Metrics table (Step 9b) shows `CLAUDE.md` exceeding 10000 bytes, p
 
 2. **Extract it:**
    - Create the target file (or append to an existing one) with the extracted content
-   - Replace the block in `CLAUDE.md` with a one-line pointer: `<!-- Detail: memory/procedural/{topic}.md -->`
-   - The pointer is a comment — it won't render but helps trace where content went
+   - Replace the block in `CLAUDE.md` with a one-line markdown pointer, e.g.: `- **Topic detail:** viz memory/procedural/{topic}.md`
+   - The pointer stays visible in CLAUDE.md so the agent (and humans) can find the extracted content
 
 3. **Log it** in the markdown report under `## CLAUDE.md Reduction`:
    - What was moved, from where to where, size delta


### PR DESCRIPTION
## Summary
- Adds Step 9c to consolidation: when CLAUDE.md exceeds 10KB threshold, extract **one block per cycle** to memory/ tiers
- Procedural/reference content → `memory/procedural/` or `memory/semantic/`; duplicates with base-brain or SUMMARY.md → delete
- Never moves identity, @imports, or core behavioral rules
- Logs each extraction in report under `## CLAUDE.md Reduction`

## Context
Jarvis's CLAUDE.md is 14.2KB (42% over 10KB threshold). Jakub's direction: agents must manage their own brains — no external intervention. Approach must be gradual (max 1 block/cycle), not big-bang, to allow detecting regressions between cycles.

## What changes
+26 lines in `skills/memory/consolidate/skill.md` — new Step 9c after Memory Metrics.

## Test plan
- [ ] Next consolidation of a brain with CLAUDE.md > 10KB should extract one block and log it
- [ ] Brain with CLAUDE.md < 10KB should skip Step 9c entirely
- [ ] Verify no eval criteria are broken (step is additive, no existing steps modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)