### PR TITLE
feat: add submit_feedback MCP tool

### DIFF
--- a/mcp/teamvibe-api.mjs
+++ b/mcp/teamvibe-api.mjs
@@ -81,6 +81,20 @@ const TOOLS = [
       required: ['scheduleId'],
     },
   },
+  {
+    name: 'submit_feedback',
+    description: 'Submit feedback about the platform (bugs, improvements, observations). Feedback is stored and consolidated by the eval pipeline. Use when a user explicitly reports an issue or when you observe a platform problem worth tracking.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: ['bug', 'improvement', 'observation'], description: 'Type of feedback' },
+        priority: { type: 'string', enum: ['low', 'medium', 'high', 'critical'], description: 'How critical is this feedback' },
+        context: { type: 'string', description: 'Description of the issue or suggestion (minimum 5 chars)' },
+        targetRepo: { type: 'string', enum: ['teamvibeai/teamvibe.ai', 'teamvibeai/poller-brain', 'teamvibeai/poller-brain-eval'], description: 'Target repository (optional)' },
+      },
+      required: ['type', 'priority', 'context'],
+    },
+  },
 ]
 
 async function handleTool(name, args) {
@@ -125,6 +139,17 @@ async function handleTool(name, args) {
     case 'delete_scheduled_message': {
       const params = new URLSearchParams({ workspaceId: WORKSPACE_ID })
       return await apiCall('DELETE', `/scheduled-messages/${args.scheduleId}?${params}`)
+    }
+
+    case 'submit_feedback': {
+      const body = {
+        channelId: CHANNEL_ID,
+        type: args.type,
+        priority: args.priority,
+        context: args.context,
+      }
+      if (args.targetRepo) body.targetRepo = args.targetRepo
+      return await apiCall('POST', '/feedback', body)
     }
 
     default:


### PR DESCRIPTION
## Summary

- Adds `submit_feedback` tool to `mcp/teamvibe-api.mjs`
- Agents can submit platform feedback (bugs, improvements, observations) with priority
- Feedback is stored in DynamoDB and consolidated by the eval pipeline

## Parameters

| Param | Type | Required | Description |
|-------|------|----------|-------------|
| `type` | `bug\|improvement\|observation` | yes | Feedback category |
| `priority` | `low\|medium\|high\|critical` | yes | Severity assessment |
| `context` | string | yes | Description (min 5 chars) |
| `targetRepo` | string | no | Suggested target repository |

## Dependencies

- Requires `teamvibe.ai#84` to be deployed first (adds `POST /feedback` API endpoint)

## Replaces

The broken `PENDING_ISSUES.md → JSON report → process-issues.yml` pipeline. Once this is live, we can remove the PENDING_ISSUES.md convention from MAINTENANCE.md.

## Test plan

- [ ] Deploy teamvibe.ai#84 to staging
- [ ] Verify MCP tool is available to agents
- [ ] Test successful feedback submission
- [ ] Verify error handling (missing params, invalid type/priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)