### PR TITLE
feat: add submit_feedback MCP tool

### DIFF
--- a/mcp/teamvibe-api.mjs
+++ b/mcp/teamvibe-api.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * TeamVibe API MCP Server — scheduled messages management.
+ * TeamVibe API MCP Server — scheduled messages & agent feedback.
  *
  * Environment variables (set by claude-spawner):
  *   TEAMVIBE_API_URL      — Poller API base URL
@@ -81,6 +81,35 @@ const TOOLS = [
       required: ['scheduleId'],
     },
   },
+  {
+    name: 'submit_feedback',
+    description: 'Submit feedback about the platform (bugs, improvements, observations). Feedback is stored in a central database and consolidated by the eval pipeline. Use when a user explicitly reports an issue or when you observe a platform problem worth tracking.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        type: {
+          type: 'string',
+          enum: ['bug', 'improvement', 'observation'],
+          description: 'Type of feedback',
+        },
+        priority: {
+          type: 'string',
+          enum: ['low', 'medium', 'high', 'critical'],
+          description: 'How critical the agent considers this feedback',
+        },
+        context: {
+          type: 'string',
+          description: 'Description of the feedback (minimum 10 characters)',
+        },
+        targetRepo: {
+          type: 'string',
+          enum: ['teamvibeai/teamvibe.ai', 'teamvibeai/poller-brain', 'teamvibeai/poller-brain-eval'],
+          description: 'Target repository (optional)',
+        },
+      },
+      required: ['type', 'priority', 'context'],
+    },
+  },
 ]
 
 async function handleTool(name, args) {
@@ -125,6 +154,17 @@ async function handleTool(name, args) {
     case 'delete_scheduled_message': {
       const params = new URLSearchParams({ workspaceId: WORKSPACE_ID })
       return await apiCall('DELETE', `/scheduled-messages/${args.scheduleId}?${params}`)
+    }
+
+    case 'submit_feedback': {
+      const body = {
+        channelId: CHANNEL_ID,
+        type: args.type,
+        priority: args.priority,
+        context: args.context,
+      }
+      if (args.targetRepo) body.targetRepo = args.targetRepo
+      return await apiCall('POST', '/feedback', body)
     }
 
     default:

--- a/mcp/teamvibe-api.mjs
+++ b/mcp/teamvibe-api.mjs
@@ -101,11 +101,6 @@ const TOOLS = [
           type: 'string',
           description: 'Description of the feedback (minimum 10 characters)',
         },
-        targetRepo: {
-          type: 'string',
-          enum: ['teamvibeai/teamvibe.ai', 'teamvibeai/poller-brain', 'teamvibeai/poller-brain-eval'],
-          description: 'Target repository (optional)',
-        },
       },
       required: ['type', 'priority', 'context'],
     },
@@ -157,14 +152,12 @@ async function handleTool(name, args) {
     }
 
     case 'submit_feedback': {
-      const body = {
+      return await apiCall('POST', '/feedback', {
         channelId: CHANNEL_ID,
         type: args.type,
         priority: args.priority,
         context: args.context,
-      }
-      if (args.targetRepo) body.targetRepo = args.targetRepo
-      return await apiCall('POST', '/feedback', body)
+      })
     }
 
     default:

--- a/skills/teamvibe-api/skill.md
+++ b/skills/teamvibe-api/skill.md
@@ -1,11 +1,12 @@
 ---
 name: teamvibe-api
 description: |
-  TeamVibe API tools for managing scheduled messages (reminders, recurring tasks, one-time triggers).
+  TeamVibe API tools for managing scheduled messages (reminders, recurring tasks, one-time triggers)
+  and submitting agent feedback (bugs, improvements, observations).
   This skill is always active — use these MCP tools when users ask to schedule, remind, or automate.
 ---
 
-# TeamVibe API — Scheduled Messages
+# TeamVibe API — Scheduled Messages & Feedback
 
 All tools are prefixed `mcp__teamvibe-api__`. Channel and workspace context are automatically set.
 
@@ -110,3 +111,35 @@ User: "Change that PR check to 9am instead"
 | Every hour | `0 * * * *` |
 | Every day at midnight | `0 0 * * *` |
 | Every 1st of month at 10am | `0 10 1 * *` |
+
+---
+
+# Agent Feedback
+
+## submit_feedback
+
+Submit feedback about the platform. Stored in a central database and consolidated by the eval pipeline.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `type` | **yes** | `bug`, `improvement`, or `observation` |
+| `priority` | **yes** | `low`, `medium`, `high`, or `critical` |
+| `context` | **yes** | Description of the feedback (min 10 chars) |
+| `targetRepo` | no | Target repo: `teamvibeai/teamvibe.ai`, `teamvibeai/poller-brain`, or `teamvibeai/poller-brain-eval` |
+
+### When to use
+
+- User explicitly reports an issue ("report this", "zapiš jako issue", "tohle nefunguje")
+- You observe a platform problem worth tracking (repeated MCP failures, missing features)
+- You want to suggest an improvement based on your experience
+
+### Example
+
+```json
+{
+  "type": "bug",
+  "priority": "high",
+  "context": "MCP fetch_failed errors occur 2-3x per session when calling read_thread. Retrying works but adds latency.",
+  "targetRepo": "teamvibeai/teamvibe.ai"
+}
+```

--- a/skills/teamvibe-api/skill.md
+++ b/skills/teamvibe-api/skill.md
@@ -125,7 +125,6 @@ Submit feedback about the platform. Stored in a central database and consolidate
 | `type` | **yes** | `bug`, `improvement`, or `observation` |
 | `priority` | **yes** | `low`, `medium`, `high`, or `critical` |
 | `context` | **yes** | Description of the feedback (min 10 chars) |
-| `targetRepo` | no | Target repo: `teamvibeai/teamvibe.ai`, `teamvibeai/poller-brain`, or `teamvibeai/poller-brain-eval` |
 
 ### When to use
 
@@ -139,7 +138,6 @@ Submit feedback about the platform. Stored in a central database and consolidate
 {
   "type": "bug",
   "priority": "high",
-  "context": "MCP fetch_failed errors occur 2-3x per session when calling read_thread. Retrying works but adds latency.",
-  "targetRepo": "teamvibeai/teamvibe.ai"
+  "context": "MCP fetch_failed errors occur 2-3x per session when calling read_thread. Retrying works but adds latency."
 }
 ```


### PR DESCRIPTION
## Summary

- Adds `submit_feedback` tool to `teamvibe-api.mjs` MCP server
- Updates skill documentation with usage guide and examples
- Agents can submit feedback (bugs, improvements, observations) with priority levels directly via MCP call

**Depends on:** teamvibeai/teamvibe.ai#86 (backend `POST /feedback` endpoint)

## Tool interface

```
submit_feedback:
  type: bug | improvement | observation (required)
  priority: low | medium | high | critical (required)
  context: string, min 10 chars (required)
  targetRepo: teamvibeai/* (optional)
```

## Test plan

- [ ] Deploy teamvibe.ai#86 first (backend endpoint)
- [ ] Verify MCP tool appears in `tools/list`
- [ ] Test successful submission returns feedbackId
- [ ] Test validation errors (missing fields, short context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)