### PR TITLE
feat: add semantic/ lifecycle pruning to consolidation

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -167,6 +167,71 @@ If MISTAKES.md has no entries or doesn't exist, skip this step.
 
 **Report tracking:** Add any promoted-to files to `filesChanged`. Add a summary of promotions (or "no mistakes to promote") to the markdown report.
 
+### 5b. Semantic File Lifecycle
+
+Scan `memory/semantic/` for stale, oversized, or redundant files. This step keeps semantic memory clean and navigable — without it, old files accumulate noise that degrades search quality.
+
+**This step MUST run before Step 6 (Regenerate SUMMARY.md)** — otherwise SUMMARY.md will contain stale pointers to files that were just deleted or renamed.
+
+#### Staleness Detection
+
+For each file in `memory/semantic/`:
+
+1. **Check last modification** — run `git log -1 --format=%ai -- <file>` to get the last commit date touching that file.
+2. **Shallow clone guard** — if `git log` returns empty (no history available, common in shallow clones after re-clone), treat the file as stale and flag it for review. Do NOT auto-delete files with missing history — only flag them for manual assessment.
+3. **Flag as stale** if not modified in 30+ days (or if history is missing per step 2).
+
+#### Actions on Stale Files
+
+For each stale file, assess its content against current knowledge:
+
+| Condition | Action |
+|-----------|--------|
+| Content is still accurate and useful | **KEEP** — no change needed (reset staleness by noting "reviewed YYYY-MM-DD" in the report) |
+| Content is partially outdated | **UPDATE** — refresh outdated sections in-place, preserve accurate parts |
+| Content is fully outdated or superseded | **DELETE** — remove the file entirely |
+| Content overlaps significantly with another semantic file | **MERGE** — combine into one file, delete the redundant one |
+
+**Conservative approach:** When unsure whether content is still relevant, KEEP it. Only DELETE when the information is clearly wrong or obsolete. Prefer UPDATE over DELETE.
+
+**Never delete a file that contains `[MEM-NNN]` ACTIVE keys** — those entries must first go through the MEM lifecycle (Step 1c) before the file can be removed.
+
+#### Size Check
+
+For all files in `memory/semantic/` (not just stale ones):
+
+1. Count lines with `wc -l`
+2. If a file exceeds **100 lines**, split it into logical sub-topics:
+   - Create new files with descriptive names (e.g., `teamvibe-architecture.md` → `teamvibe-architecture-infra.md` + `teamvibe-architecture-api.md`)
+   - Delete the oversized original
+   - Update any pointers in `TODAY.md` that reference the old filename
+
+**Do not split aggressively** — only split when the file covers clearly distinct sub-topics. A 120-line file about one cohesive topic is fine.
+
+#### Merge Detection
+
+When processing stale files, also check for merge candidates among non-stale files:
+- Two or more files under 20 lines covering the same topic → merge into one
+- Files with nearly identical names or overlapping content → merge
+
+#### Report Tracking
+
+Add a `## Semantic Lifecycle` section to the markdown report:
+
+```markdown
+## Semantic Lifecycle
+- Files scanned: 8
+- Stale (30+ days): 3 (1 via shallow clone fallback)
+- Actions: 1 KEEP (reviewed), 1 UPDATE (refreshed), 1 DELETE (obsolete)
+- Oversized (>100 lines): 1 (split into 2 files)
+- Merges: 0
+- Files changed: semantic/old-topic.md (deleted), semantic/architecture.md (updated)
+```
+
+Add any created, updated, or deleted semantic files to `filesChanged`. Set `selfAssessment["semantic-lifecycle-checked"]` to `true`.
+
+If `memory/semantic/` doesn't exist or is empty, skip this step and set `selfAssessment["semantic-lifecycle-checked"]` to `true` (nothing to check).
+
 ### 6. Regenerate SUMMARY.md
 
 **Always regenerate `memory/SUMMARY.md` on every consolidation run — this step is non-negotiable, even if no facts were promoted in steps 2–4.** A lightweight consolidation with zero promotions must still regenerate SUMMARY.md to ensure it reflects the current state of all memory tiers.
@@ -198,68 +263,6 @@ For daily log files (format: `YYYY-MM-DD.md`) in `memory/daily/` that are older 
 - After deletion, verify no files dated more than 30 days ago remain in `memory/daily/`.
 
 **Recent-log retention (non-negotiable):** NEVER delete `memory/daily/<today>.md` or `memory/daily/<yesterday>.md`, regardless of whether their contents have been promoted. Same-day and next-day sessions rely on these files to recover context. Promotion is not a reason to delete; deletion is only for files dated 30+ days ago.
-
-### 7b. Semantic File Lifecycle
-
-Scan `memory/semantic/` for stale, oversized, or redundant files. This step keeps semantic memory clean and navigable — without it, old files accumulate noise that degrades search quality.
-
-#### Staleness Detection
-
-For each file in `memory/semantic/`:
-
-1. **Check last modification** — use `git log -1 --format=%ai -- <file>` to get the last commit date touching that file.
-2. **Flag as stale** if not modified in 30+ days.
-
-#### Actions on Stale Files
-
-For each stale file, assess its content against current knowledge:
-
-| Condition | Action |
-|-----------|--------|
-| Content is still accurate and useful | **KEEP** — no change needed (reset staleness by noting "reviewed YYYY-MM-DD" in the report) |
-| Content is partially outdated | **UPDATE** — refresh outdated sections in-place, preserve accurate parts |
-| Content is fully outdated or superseded | **DELETE** — remove the file entirely |
-| Content overlaps significantly with another semantic file | **MERGE** — combine into one file, delete the redundant one |
-
-**Conservative approach:** When unsure whether content is still relevant, KEEP it. Only DELETE when the information is clearly wrong or obsolete. Prefer UPDATE over DELETE.
-
-**Never delete a file that contains `[MEM-NNN]` ACTIVE keys** — those entries must first go through the MEM lifecycle (Step 1c) before the file can be removed.
-
-#### Size Check
-
-For all files in `memory/semantic/` (not just stale ones):
-
-1. Count lines with `wc -l`
-2. If a file exceeds **100 lines**, split it into logical sub-topics:
-   - Create new files with descriptive names (e.g., `teamvibe-architecture.md` → `teamvibe-architecture-infra.md` + `teamvibe-architecture-api.md`)
-   - Delete the oversized original
-   - Update any pointers in `SUMMARY.md` or `TODAY.md` that reference the old filename
-
-**Do not split aggressively** — only split when the file covers clearly distinct sub-topics. A 120-line file about one cohesive topic is fine.
-
-#### Merge Detection
-
-When processing stale files, also check for merge candidates among non-stale files:
-- Two or more files under 20 lines covering the same topic → merge into one
-- Files with nearly identical names or overlapping content → merge
-
-#### Report Tracking
-
-Add a `## Semantic Lifecycle` section to the markdown report:
-
-```markdown
-## Semantic Lifecycle
-- Files scanned: 8
-- Stale (30+ days): 3
-- Actions: 1 KEEP (reviewed), 1 UPDATE (refreshed), 1 DELETE (obsolete)
-- Oversized (>100 lines): 1 (split into 2 files)
-- Merges: 0
-- Files changed: semantic/old-topic.md (deleted), semantic/architecture.md (updated)
-```
-
-Add any created, updated, or deleted semantic files to `filesChanged`. Set `selfAssessment["semantic-lifecycle-checked"]` to `true`.
-
-If `memory/semantic/` doesn't exist or is empty, skip this step and set `selfAssessment["semantic-lifecycle-checked"]` to `true` (nothing to check).
 
 ### 8. Update Timestamp
 

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -199,6 +199,68 @@ For daily log files (format: `YYYY-MM-DD.md`) in `memory/daily/` that are older 
 
 **Recent-log retention (non-negotiable):** NEVER delete `memory/daily/<today>.md` or `memory/daily/<yesterday>.md`, regardless of whether their contents have been promoted. Same-day and next-day sessions rely on these files to recover context. Promotion is not a reason to delete; deletion is only for files dated 30+ days ago.
 
+### 7b. Semantic File Lifecycle
+
+Scan `memory/semantic/` for stale, oversized, or redundant files. This step keeps semantic memory clean and navigable — without it, old files accumulate noise that degrades search quality.
+
+#### Staleness Detection
+
+For each file in `memory/semantic/`:
+
+1. **Check last modification** — use `git log -1 --format=%ai -- <file>` to get the last commit date touching that file.
+2. **Flag as stale** if not modified in 30+ days.
+
+#### Actions on Stale Files
+
+For each stale file, assess its content against current knowledge:
+
+| Condition | Action |
+|-----------|--------|
+| Content is still accurate and useful | **KEEP** — no change needed (reset staleness by noting "reviewed YYYY-MM-DD" in the report) |
+| Content is partially outdated | **UPDATE** — refresh outdated sections in-place, preserve accurate parts |
+| Content is fully outdated or superseded | **DELETE** — remove the file entirely |
+| Content overlaps significantly with another semantic file | **MERGE** — combine into one file, delete the redundant one |
+
+**Conservative approach:** When unsure whether content is still relevant, KEEP it. Only DELETE when the information is clearly wrong or obsolete. Prefer UPDATE over DELETE.
+
+**Never delete a file that contains `[MEM-NNN]` ACTIVE keys** — those entries must first go through the MEM lifecycle (Step 1c) before the file can be removed.
+
+#### Size Check
+
+For all files in `memory/semantic/` (not just stale ones):
+
+1. Count lines with `wc -l`
+2. If a file exceeds **100 lines**, split it into logical sub-topics:
+   - Create new files with descriptive names (e.g., `teamvibe-architecture.md` → `teamvibe-architecture-infra.md` + `teamvibe-architecture-api.md`)
+   - Delete the oversized original
+   - Update any pointers in `SUMMARY.md` or `TODAY.md` that reference the old filename
+
+**Do not split aggressively** — only split when the file covers clearly distinct sub-topics. A 120-line file about one cohesive topic is fine.
+
+#### Merge Detection
+
+When processing stale files, also check for merge candidates among non-stale files:
+- Two or more files under 20 lines covering the same topic → merge into one
+- Files with nearly identical names or overlapping content → merge
+
+#### Report Tracking
+
+Add a `## Semantic Lifecycle` section to the markdown report:
+
+```markdown
+## Semantic Lifecycle
+- Files scanned: 8
+- Stale (30+ days): 3
+- Actions: 1 KEEP (reviewed), 1 UPDATE (refreshed), 1 DELETE (obsolete)
+- Oversized (>100 lines): 1 (split into 2 files)
+- Merges: 0
+- Files changed: semantic/old-topic.md (deleted), semantic/architecture.md (updated)
+```
+
+Add any created, updated, or deleted semantic files to `filesChanged`. Set `selfAssessment["semantic-lifecycle-checked"]` to `true`.
+
+If `memory/semantic/` doesn't exist or is empty, skip this step and set `selfAssessment["semantic-lifecycle-checked"]` to `true` (nothing to check).
+
 ### 8. Update Timestamp
 
 Write the current date to `memory/.last_consolidation`:


### PR DESCRIPTION
## Summary

Closes #62.

- Adds **Step 7b** to the consolidation algorithm — scans `memory/semantic/` for stale, oversized, and redundant files
- **Staleness detection:** flags files not modified in 30+ days (via `git log`), then assesses: KEEP / UPDATE / DELETE / MERGE
- **Size check:** files >100 lines get split into logical sub-topics
- **Merge detection:** small files (<20 lines) on same topic get combined
- Conservative approach — KEEP by default, never delete files with ACTIVE `[MEM-NNN]` keys

## Design decisions

- Uses `git log -1 --format=%ai` for staleness (reliable, no extra tooling)
- 30-day threshold matches daily/ log pruning for consistency
- Split threshold at 100 lines (from original issue + memory skill naming convention)
- Report section `## Semantic Lifecycle` + `selfAssessment["semantic-lifecycle-checked"]` for eval tracking

## Test plan

- [ ] Run consolidation on a brain with semantic/ files (some stale, some fresh)
- [ ] Verify stale files are flagged and appropriate action taken
- [ ] Verify oversized files get split recommendation
- [ ] Verify report includes `## Semantic Lifecycle` section
- [ ] Verify `selfAssessment["semantic-lifecycle-checked"]` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)