### PR TITLE
docs: heartbeat reliability + promptTemplate best practices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,8 @@ You may receive periodic heartbeat messages. When you do:
 3. Remove completed one-time tasks from HEARTBEAT.md
 4. If nothing needs attention, do nothing (no reply needed)
 
+**Heartbeat reliability:** Heartbeat is best-effort, not guaranteed. Intervals vary (typically 5–30 min, but gaps can occur due to system load or maintenance). Treat heartbeat as a safety net for periodic checks, not a precise timer. For time-critical tasks, use scheduled messages (`create_scheduled_message`) with explicit timing instead of deferring to heartbeat.
+
 ### Managing Tasks
 When a user asks you to remember, track, or follow up on something:
 - Add it to `HEARTBEAT.md` as a checklist item with context and date

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ You may receive periodic heartbeat messages. When you do:
 3. Remove completed one-time tasks from HEARTBEAT.md
 4. If nothing needs attention, do nothing (no reply needed)
 
-**Heartbeat reliability:** Heartbeat is best-effort, not guaranteed. Intervals vary (typically 5–30 min, but gaps can occur due to system load or maintenance). Treat heartbeat as a safety net for periodic checks, not a precise timer. For time-critical tasks, use scheduled messages (`create_scheduled_message`) with explicit timing instead of deferring to heartbeat.
+**Heartbeat reliability:** Heartbeat is best-effort, not guaranteed. Intervals are variable and not guaranteed — gaps can occur due to system load or maintenance. Treat heartbeat as a safety net for periodic checks, not a precise timer. For time-critical tasks, use scheduled messages (`create_scheduled_message`) with explicit timing instead of deferring to heartbeat.
 
 ### Managing Tasks
 When a user asks you to remember, track, or follow up on something:

--- a/skills/teamvibe-api/skill.md
+++ b/skills/teamvibe-api/skill.md
@@ -59,6 +59,40 @@ The `promptTemplate` is **an instruction to yourself** (Claude), not the message
 - `"Check PRs"` — Too vague. Which repo? What to do with results?
 - `"Reply to the thread with a reminder"` — No thread_ts specified; the session has no thread context, so this will post to channel root.
 
+## Best Practices
+
+### Data-before-reference rule
+
+Never send a message referencing an output (file, URL, generated data) before that output exists. If the session crashes between the message and data generation, the user gets broken references.
+
+**Valid pattern:**
+```
+1. send_message("Generating report...")         ← no output references
+2. Generate data, write files, fetch results
+3. send_message in thread with results + links  ← outputs exist
+```
+
+**Invalid pattern:**
+```
+1. send_message("Here's your report: <link>")   ← link references non-existent output
+2. Generate the report                           ← session crash = broken link
+```
+
+Informational messages (status updates, "starting..." notifications) can be sent at any time since they don't reference outputs.
+
+### Step ordering in promptTemplate
+
+When your `promptTemplate` involves multiple steps, order them defensively:
+1. **Gather data first** — fetch, compute, generate
+2. **Validate results** — check for errors or empty responses
+3. **Send message last** — only after you have confirmed output to share
+
+### Partial failure handling
+
+If a scheduled task partially fails (e.g., data fetch works but formatting breaks):
+- Send what you have with a note about what failed
+- Don't silently fail — a partial result is better than no response
+
 ## Examples
 
 ### Recurring (CRON)

--- a/skills/teamvibe-api/skill.md
+++ b/skills/teamvibe-api/skill.md
@@ -91,6 +91,7 @@ When your `promptTemplate` involves multiple steps, order them defensively:
 
 If a scheduled task partially fails (e.g., data fetch works but formatting breaks):
 - Send what you have with a note about what failed
+- Log the failure to TODAY.md for traceability
 - Don't silently fail — a partial result is better than no response
 
 ## Examples


### PR DESCRIPTION
## Summary

Closes #26.

- **CLAUDE.md:** Added heartbeat reliability note — clarifies it's best-effort with variable intervals, recommends scheduled messages for time-critical tasks
- **teamvibe-api skill:** Added "Best Practices" section with:
  - Data-before-reference rule (don't send messages referencing outputs that don't exist yet)
  - Step ordering guidance for promptTemplate (gather → validate → send)
  - Partial failure handling (send what you have, don't silently fail)

## Test plan

- [ ] Verify CLAUDE.md renders correctly in agent context
- [ ] Verify teamvibe-api skill Best Practices section is coherent with existing examples
- [ ] Check no duplication with existing promptTemplate rules section

🤖 Generated with [Claude Code](https://claude.com/claude-code)