### PR TITLE
fix: stop logging no-op heartbeats to TODAY.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ You may receive periodic heartbeat messages. When you do:
 1. Read BOTH your channel's `HEARTBEAT.md` AND the base brain's `MAINTENANCE.md`
 2. Execute any pending/due tasks from both files
 3. Remove completed one-time tasks from HEARTBEAT.md
-4. If nothing needs attention, do nothing (no reply needed)
+4. If nothing needs attention, do nothing (no reply needed, **no log entry needed**)
 
 **Heartbeat reliability:** Heartbeat is best-effort, not guaranteed. Intervals are variable and not guaranteed — gaps can occur due to system load or maintenance. Treat heartbeat as a safety net for periodic checks, not a precise timer. For time-critical tasks, use scheduled messages (`create_scheduled_message`) with explicit timing instead of deferring to heartbeat.
 

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -57,7 +57,9 @@ As you work, append a timestamped one-liner to **`memory/TODAY.md`** whenever an
 
 Rules:
 - **Write to `memory/TODAY.md`** — this is the primary daily log target. It gets archived to `memory/daily/YYYY-MM-DD.md` during maintenance.
-- **Minimum entry rule (non-negotiable):** Every session must create at least one log entry — even heartbeat, maintenance, triage, health-check, or automated sessions with no user interaction. Write the entry **before** any action that could fail or time out — if the session crashes, the log still has value. If nothing notable happened: `- 09:00 — heartbeat ran, no user interactions, no new content` or `- 09:00 — WF triage ran, 0 failures`. No session ends with zero log entries.
+- **Minimum entry rule:** Every session that *performs a meaningful action* must create at least one log entry. This includes interactive sessions, maintenance that modifies files, heartbeats that execute tasks, triage runs, and health checks. Write the entry **before** any action that could fail or time out — if the session crashes, the log still has value.
+  - **Exception — no-op heartbeats:** If a heartbeat session checks tasks and finds nothing to do (no pending tasks, no maintenance due, no actions taken), do **NOT** log anything. Silent exit is correct. Only log heartbeats that actually performed work (e.g., ran consolidation, completed a task, triggered a workflow).
+  - **What to log when something happened:** `- 09:00 — heartbeat: ran consolidation, archived 3 daily logs` or `- 09:00 — WF triage ran, 2 failures (created WF-123)`. Keep it to what was *done*, not what was *skipped*.
 - **Append continuously, not at the end.** If the session ends abruptly (crash, context compaction, timeout), the log still has value because you wrote as you went.
 - **Don't batch-decide "what was important."** If you're unsure whether an entry is worth it, write it — removing noise is cheap during consolidation, reconstructing lost context is not.
 - **One line per entry is fine.** Brief is better than nothing.
@@ -67,7 +69,7 @@ Rules:
 # 2026-03-17
 
 - 09:00 — WF triage ran, 2 failures (erpio-gw login, rekap-dev deploy), created WF-123
-- 09:15 — check-triage ran, 0 failures, all systems OK
+- 09:15 — heartbeat: completed task "check PR #456 status" — merged, removed from HEARTBEAT.md
 - 14:30 — Learned that Alice prefers email over Slack for approvals
 - 14:45 — Fixed the deploy script; root cause was missing AWS region
 - 15:10 — User corrected: reports should go to #general, not #reports


### PR DESCRIPTION
## Summary

- No-op heartbeat sessions (nothing to execute) no longer require a daily log entry
- Only heartbeats that perform actual work (consolidation, task completion, workflow triggers) are logged
- Reinforced in CLAUDE.md heartbeat section: "no log entry needed" for no-op heartbeats

## Problem

TODAY.md was being flooded with 50+ identical lines like:
```
heartbeat: routine status check, pipeline healthy
heartbeat #35: no-op (guard exit 1, outside 0-6 UTC window...)
```

Root cause: the "minimum entry rule" in `skills/memory/skill.md` required *every* session (including no-op heartbeats) to create at least one log entry. This drowned out real content and bloated git history.

## Changes

- `skills/memory/skill.md` — rewrote the minimum entry rule with explicit exception for no-op heartbeats
- `CLAUDE.md` — added "no log entry needed" clarification to heartbeat section

## Test plan

- [ ] Deploy to staging and verify agents stop logging no-op heartbeats
- [ ] Verify heartbeats that DO perform work still log correctly
- [ ] Check that interactive sessions still enforce minimum entry rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)