### PR TITLE
Deprecate heartbeat — migrate to scheduled messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,31 +225,47 @@ You can attach multiple modals to one message — each gets its own button:
 - Each input block needs a unique `block_id` and the element needs an `action_id` — these become the field names in submission data
 - The `action_id` values from your input elements become the keys in the submission values
 
-## Heartbeat & Task Management
+## Task Scheduling & Heartbeat (DEPRECATED)
 
-You may receive periodic heartbeat messages. When you do:
-1. Read BOTH your channel's `HEARTBEAT.md` AND the base brain's `MAINTENANCE.md`
-2. Execute any pending/due tasks from both files
-3. Remove completed one-time tasks from HEARTBEAT.md
-4. If nothing needs attention, do nothing (no reply needed, **no log entry needed**)
+> **Status:** Heartbeat is being deprecated in favor of `create_scheduled_message` and event triggers. Tracked in `teamvibeai/teamvibe.ai#102`. **Do NOT add new HEARTBEAT.md tasks** — schedule them explicitly instead.
 
-**Heartbeat reliability:** Heartbeat is best-effort, not guaranteed. Intervals are variable and not guaranteed — gaps can occur due to system load or maintenance. Treat heartbeat as a safety net for periodic checks, not a precise timer. For time-critical tasks, use scheduled messages (`create_scheduled_message`) with explicit timing instead of deferring to heartbeat.
+### When a user asks you to track / remember / follow up on something
 
-### Managing Tasks
-When a user asks you to remember, track, or follow up on something:
-- Add it to `HEARTBEAT.md` as a checklist item with context and date
-- Mark one-time tasks clearly so you remove them after completion
-- Keep the file small — completed items should be cleaned up
+Use `mcp__teamvibe-api__create_scheduled_message` with explicit `runAt` (one-time) or `cron` (recurring). See the `teamvibe-api` skill for the full parameter reference.
 
-Example `HEARTBEAT.md`:
-```markdown
-# Periodic Tasks
-- [ ] Check if PR #123 is merged (one-time, added 2026-03-10)
-- [x] Follow up on email from John (done, remove next heartbeat)
+```typescript
+// One-time follow-up:
+create_scheduled_message({
+  runAt: "2026-05-13T09:00:00Z",
+  promptTemplate: "Check if PR #123 is merged. If not, ping the assignee."
+})
 
-# Recurring
-- Check unread emails and notify if urgent
+// Recurring task:
+create_scheduled_message({
+  cron: "0 7 * * 1-5",   // weekday mornings 07:00 UTC
+  promptTemplate: "Run morning health check and post summary."
+})
 ```
+
+### Heartbeat handling (transitional)
+
+The platform still sends periodic heartbeat messages while migration is in progress. When one arrives:
+1. If your channel still has a `HEARTBEAT.md`, read it; otherwise skip.
+2. Read `MAINTENANCE.md` for universal tasks.
+3. Execute any pending/due items.
+4. **Migrate any remaining `HEARTBEAT.md` items to scheduled messages and delete them from the file.** Goal state: `HEARTBEAT.md` empty or removed.
+5. If nothing to do, silent exit — **no log entry**.
+
+### Migration recipe for existing HEARTBEAT.md items
+
+For each `- [ ]` line:
+- *One-time check* (e.g. `Check if PR #123 is merged on 2026-05-15`) → `create_scheduled_message({ runAt: "2026-05-15T08:00:00Z", promptTemplate: "..." })`
+- *Recurring* (e.g. `Check unread emails daily`) → `create_scheduled_message({ cron: "0 8 * * *", promptTemplate: "..." })`
+- Delete the line from `HEARTBEAT.md` once the scheduled message is created.
+
+When `HEARTBEAT.md` becomes empty, delete the file.
+
+**Heartbeat reliability:** intervals are variable / best-effort. Never depend on heartbeat for time-critical work — always use scheduled messages.
 
 ### Reporting Issues
 When a user explicitly asks to report an issue about the platform or base brain (e.g., "zapiš jako issue", "report this", "pošli jako issue"), write it to `PENDING_ISSUES.md`. The issue will be included in your next maintenance report and processed into a GitHub issue. See MAINTENANCE.md for the full convention.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -129,7 +129,7 @@ The JSON file is written at the same time as the markdown report, in the same co
 | `selfAssessment` | `object` | Boolean pass/fail per eval criterion (see Eval Criteria below) |
 | `processImprovements` | `string[]` | Self-critique and proposals for process improvement. Each entry must be prefixed with `[self-critique]`, `[proposal]`, or `[blocked]`. At least one entry required per reflection. |
 | `pendingIssues` | `object[]` | Issues reported by users for creation on GitHub. Each object: `repo` (target repository), `title`, `context` (user's description), `reportedBy` (who reported), `date`. Empty array or omitted if none. See Pending Issues section below. |
-| `heartbeatStatus` | `object` | Self-reported state of the brain's `HEARTBEAT.md` file at consolidation time. `present` (bool): file exists. `nonEmpty` (bool): file contains at least one line that isn't blank, a heading, or an HTML comment. `itemCount` (int): number of unchecked task lines (`- [ ]`). Used by eval pipeline to track heartbeat deprecation progress (`teamvibeai/teamvibe.ai#102`). |
+| `heartbeatStatus` | `object` | Self-reported state of the brain's `HEARTBEAT.md` file at consolidation time. `present` (bool): file exists. `nonEmpty` (bool): file contains at least one line that is not blank, a heading, an HTML comment, or a completed `- [x]` task. `itemCount` (int): number of unchecked task lines (`- [ ]`). Used by eval pipeline to track heartbeat deprecation progress (`teamvibeai/teamvibe.ai#102`). |
 | `brainCommitSha` | `string` | Output of `git rev-parse HEAD` at the time of the report |
 
 **Rules:**

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,7 +1,7 @@
 # Base Brain Maintenance
 
 These tasks are universal — they apply to all agents regardless of workspace.
-During heartbeat sessions, execute these alongside your channel's HEARTBEAT.md tasks.
+Execute them during scheduled maintenance sessions. (Legacy: heartbeat sessions also trigger them while heartbeat is being phased out — see CLAUDE.md "Task Scheduling & Heartbeat" section. Tracked in `teamvibeai/teamvibe.ai#102`.)
 
 ## Reporting Convention
 
@@ -226,3 +226,16 @@ Users can ask you to report issues about the platform or base brain. When a user
 ## Twice Weekly
 
 - **Memory reflection**: Check `memory/episodic/reflection-*.md` for the last reflection date. If 3+ days old (or none exist), run the memory-reflect skill to assess memory quality. **Produce a report.**
+
+## Heartbeat → Scheduled Messages Migration
+
+Heartbeat is deprecated (`teamvibeai/teamvibe.ai#102`). During every consolidation, agents MUST sweep `HEARTBEAT.md` if it exists in the channel brain:
+
+1. Read `HEARTBEAT.md`. For each unchecked `- [ ]` task:
+   - Convert to a `create_scheduled_message` call (`runAt` for one-time, `cron` for recurring) — see CLAUDE.md "Migration recipe" section.
+   - Delete the migrated line from `HEARTBEAT.md`.
+2. Remove all completed `- [x]` lines.
+3. If the file is now empty (or contains only headings/comments), delete it.
+4. Record in the consolidation report's `decisions`: how many items migrated, file kept or deleted.
+
+The goal is `HEARTBEAT.md` absent from every brain repo so the platform-side heartbeat code can be removed.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -107,6 +107,11 @@ The JSON file is written at the same time as the markdown report, in the same co
       "date": "2026-04-26"
     }
   ],
+  "heartbeatStatus": {
+    "present": false,
+    "nonEmpty": false,
+    "itemCount": 0
+  },
   "brainCommitSha": "abc123def456789..."
 }
 ```
@@ -124,6 +129,7 @@ The JSON file is written at the same time as the markdown report, in the same co
 | `selfAssessment` | `object` | Boolean pass/fail per eval criterion (see Eval Criteria below) |
 | `processImprovements` | `string[]` | Self-critique and proposals for process improvement. Each entry must be prefixed with `[self-critique]`, `[proposal]`, or `[blocked]`. At least one entry required per reflection. |
 | `pendingIssues` | `object[]` | Issues reported by users for creation on GitHub. Each object: `repo` (target repository), `title`, `context` (user's description), `reportedBy` (who reported), `date`. Empty array or omitted if none. See Pending Issues section below. |
+| `heartbeatStatus` | `object` | Self-reported state of the brain's `HEARTBEAT.md` file at consolidation time. `present` (bool): file exists. `nonEmpty` (bool): file contains at least one line that isn't blank, a heading, or an HTML comment. `itemCount` (int): number of unchecked task lines (`- [ ]`). Used by eval pipeline to track heartbeat deprecation progress (`teamvibeai/teamvibe.ai#102`). |
 | `brainCommitSha` | `string` | Output of `git rev-parse HEAD` at the time of the report |
 
 **Rules:**
@@ -237,5 +243,16 @@ Heartbeat is deprecated (`teamvibeai/teamvibe.ai#102`). During every consolidati
 2. Remove all completed `- [x]` lines.
 3. If the file is now empty (or contains only headings/comments), delete it.
 4. Record in the consolidation report's `decisions`: how many items migrated, file kept or deleted.
+5. Populate `heartbeatStatus` in the JSON report (always — even when `HEARTBEAT.md` does not exist):
+
+   ```json
+   "heartbeatStatus": {
+     "present": <true if HEARTBEAT.md exists at brainCommitSha, else false>,
+     "nonEmpty": <true if file has any line that isn't blank/heading/HTML comment>,
+     "itemCount": <number of unchecked '- [ ]' lines>
+   }
+   ```
+
+   This is the canonical signal the eval pipeline aggregates to track deprecation progress. Channel brain repos are private and distributed across customer GH orgs — the eval pipeline cannot read them directly, so each brain MUST self-report.
 
 The goal is `HEARTBEAT.md` absent from every brain repo so the platform-side heartbeat code can be removed.

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -275,22 +275,30 @@ YYYY-MM-DD
 
 Heartbeat is being deprecated (`teamvibeai/teamvibe.ai#102`). Channel brain repos are private and live in customer GH orgs — the platform cannot inspect them. Each brain MUST self-report `HEARTBEAT.md` state so the eval pipeline can track migration progress.
 
+**All scheduled times below are UTC.** `runAt` is ISO-8601 UTC, `cron` follows standard 5-field syntax in UTC. Do NOT use local time — agents run across timezones and the platform interprets schedules as UTC.
+
 1. **Sweep** — if `HEARTBEAT.md` exists in the brain root:
-   - For every unchecked `- [ ]` task: convert to a `create_scheduled_message` call (`runAt` for one-time, `cron` for recurring — see CLAUDE.md "Migration recipe"), then delete the line.
+   - For every unchecked `- [ ]` task:
+     - Read the task text. If older than 30 days (per the `(added YYYY-MM-DD)` annotation or git blame on that line) and no longer relevant, mention it in `decisions` and delete it without scheduling — don't blindly schedule stale work.
+     - Otherwise, write a clear `promptTemplate` for `create_scheduled_message` that restates the task in imperative form ("Check if PR #123 is merged. If not, ping the assignee."). Include any context the agent will need (links, deadlines).
+     - Call `create_scheduled_message`. **If the call fails, leave the line in place and continue with the next item** — do NOT delete the source line until you have confirmation that the schedule was created. Record the failure in `decisions`.
+     - Once the call succeeds, delete the migrated line.
    - Remove all completed `- [x]` lines.
    - If the file then has no real content (only blank lines, headings, or HTML comments), delete it.
    - Add `HEARTBEAT.md` to the JSON report's `filesChanged` if it was modified or deleted.
-   - Include in `decisions`: how many items were migrated and whether the file was kept or deleted.
+   - Include in `decisions`: how many items were migrated, how many deferred (failures or stale), file kept or deleted.
 
 2. **Self-report** — populate `heartbeatStatus` in the JSON report (always, even when `HEARTBEAT.md` does not exist):
 
    ```json
    "heartbeatStatus": {
      "present": <bool: file exists at brain root after sweep>,
-     "nonEmpty": <bool: file has any line that isn't blank/heading/HTML comment>,
+     "nonEmpty": <bool: file has any non-task content line — see definition below>,
      "itemCount": <int: number of unchecked '- [ ]' lines>
    }
    ```
+
+   **`nonEmpty` definition:** true if the file contains at least one line that is NOT one of: blank, a heading (`#`), an HTML comment, or a completed `- [x]` task line. This means a file with only completed tasks counts as empty (the next sweep will remove them anyway).
 
    Goal state: `present: false`. The eval pipeline aggregates this across all reports to know when platform-side heartbeat code can be removed (`teamvibe.ai#101`).
 

--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -271,6 +271,29 @@ Write the current date to `memory/.last_consolidation`:
 YYYY-MM-DD
 ```
 
+### 8b. Heartbeat Sweep & Self-Report
+
+Heartbeat is being deprecated (`teamvibeai/teamvibe.ai#102`). Channel brain repos are private and live in customer GH orgs — the platform cannot inspect them. Each brain MUST self-report `HEARTBEAT.md` state so the eval pipeline can track migration progress.
+
+1. **Sweep** — if `HEARTBEAT.md` exists in the brain root:
+   - For every unchecked `- [ ]` task: convert to a `create_scheduled_message` call (`runAt` for one-time, `cron` for recurring — see CLAUDE.md "Migration recipe"), then delete the line.
+   - Remove all completed `- [x]` lines.
+   - If the file then has no real content (only blank lines, headings, or HTML comments), delete it.
+   - Add `HEARTBEAT.md` to the JSON report's `filesChanged` if it was modified or deleted.
+   - Include in `decisions`: how many items were migrated and whether the file was kept or deleted.
+
+2. **Self-report** — populate `heartbeatStatus` in the JSON report (always, even when `HEARTBEAT.md` does not exist):
+
+   ```json
+   "heartbeatStatus": {
+     "present": <bool: file exists at brain root after sweep>,
+     "nonEmpty": <bool: file has any line that isn't blank/heading/HTML comment>,
+     "itemCount": <int: number of unchecked '- [ ]' lines>
+   }
+   ```
+
+   Goal state: `present: false`. The eval pipeline aggregates this across all reports to know when platform-side heartbeat code can be removed (`teamvibe.ai#101`).
+
 ### 9. MEM Audit & Memory Metrics
 
 Run integrity checks on the MEM registry and collect memory size metrics.


### PR DESCRIPTION
Closes #86. Tracked in teamvibeai/teamvibe.ai#102.

## What changes

**CLAUDE.md** — `Heartbeat & Task Management` section rewritten as deprecation notice:
- New rule: do NOT add new tasks to `HEARTBEAT.md`. Use `create_scheduled_message` (`runAt` for one-time, `cron` for recurring).
- Migration recipe with concrete examples.
- Heartbeat handling kept as transitional — when a heartbeat fires, agents must migrate any remaining `HEARTBEAT.md` items in the same session.
- Goal state: `HEARTBEAT.md` empty or removed across all brains.

**MAINTENANCE.md**
- Header decoupled from heartbeat ("execute during scheduled maintenance sessions").
- New `Heartbeat → Scheduled Messages Migration` section: every consolidation MUST sweep `HEARTBEAT.md` and migrate or delete entries.
- **JSON report schema**: new `heartbeatStatus: { present, nonEmpty, itemCount }` field. This is how the eval pipeline tracks deprecation progress — channel brains are private repos in customer GH orgs, the eval pipeline has no GH access to them, so brains must self-report.

**skills/memory/consolidate/skill.md**
- New **Step 8b — Heartbeat Sweep & Self-Report**: do the migration AND populate `heartbeatStatus` in the JSON report every run (even when `HEARTBEAT.md` is absent).

## Why
VibeKeeper + Jarvis konsensus (2026-05-06) — heartbeat is legacy; `create_scheduled_message` covers everything it does without no-op LLM calls or variable cadence. Audit: only 1/2 `*-brain` repos visible in `teamvibeai` org currently use `HEARTBEAT.md` (`vibe-keeper-brain`).

## What's NOT changed
- Platform-side heartbeat code (`teamvibe.ai#101`, gated on aggregated `heartbeatStatus.present` reaching 0 for 7 consecutive days).
- Eval pipeline aggregation logic — separate PR (replaces the closed `poller-brain-eval#107`).
- External alerting heartbeat (`teamvibe.ai#74`, different concern, kept).

## Rollout
1. Merge this PR → next consolidation cycle, every brain sweeps HEARTBEAT.md AND populates `heartbeatStatus`.
2. New eval PR (coming) aggregates `heartbeatStatus` from the existing report stream.
3. After 7 consecutive days of `heartbeatStatus.present = false` across all brains → trigger `teamvibe.ai#101`.

## Test plan
- [ ] Rendered Markdown reads cleanly.
- [ ] vibe-keeper-brain (only brain currently using HEARTBEAT.md) successfully migrates its tasks AND populates `heartbeatStatus` during next consolidation.
- [ ] No regression in existing maintenance flow — consolidation reports still produced and accepted by Internal API.