### PR TITLE
reflect: nudge brains toward gap+consequence observations (eval#135)

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -38,10 +38,19 @@ Look for conflicting information across memory files:
 
 ### 3. Gap Analysis
 
-Identify areas where memory is thin:
+Identify memory gaps AND name the concrete operational consequence — what actually went wrong in recent cycles because of the gap. A gap with no observed impact is structural noise; a gap tied to an observed problem is actionable.
+
+Look at the last 1–2 maintenance cycles (consolidation reports, prior reflections, recent daily logs) for the consequence — not the abstract future risk.
+
+- *Gap-only (not enough):* "Core memory lacks project X context."
+- *Gap + observed consequence (the bar):* "Core memory lacks project X context, which caused 3 duplicate pattern entries in last week's consolidations."
+
+Candidate gap classes to scan:
 - Frequently discussed topics with no semantic memory entry
 - Team members mentioned often but with no profile in semantic/
 - Recurring tasks with no procedural documentation
+
+If a gap exists but has not yet produced any observed consequence, do not log it as an observation. Move it to `processImprovements` as `[proposal] would like to capture X` so future cycles know it is on the radar without inflating the gap list.
 
 **Action:** Create placeholder files noting the gap for future capture:
 ```markdown
@@ -89,12 +98,12 @@ Produce both a markdown and JSON report in `reports/` as required by MAINTENANCE
 
 **JSON:** `reports/YYYY-MM-DD-memory-reflection.json` — populate every field:
 
-- `observations`: List specific findings from this reflection. Each entry should name a concrete memory strength or gap found. Examples:
-  - "semantic/team-members.md has complete profiles for all 4 active members"
-  - "memory/core/LEARNINGS.md has grown to 80 lines — approaching prune threshold"
-  - "No procedural documentation exists for the weekly-standup workflow despite it recurring 5+ times"
-  - "episodic/ covers last 3 months well; older events missing"
-  - Leave no entry vague — "memory looks good" does NOT qualify.
+- `observations`: List specific findings from this reflection. Each entry should name a concrete memory strength, OR pair a memory gap with the *operational consequence it has already produced* in recent maintenance cycles. Gap-only observations ("X is missing", "Y is thin") do NOT qualify — they go to `processImprovements` as `[proposal]` instead. Examples:
+  - "semantic/team-members.md has complete profiles for all 4 active members" — concrete strength
+  - "memory/core/LEARNINGS.md has grown to 80 lines and the last 2 promotions appended new bullets rather than merging into the existing entry, creating 3 near-duplicate rules" — gap + observed consequence
+  - "No procedural documentation exists for the weekly-standup workflow, which led to 4 inconsistent invocations across the last 5 standup runs" — gap + observed consequence
+  - "episodic/ covers the last 3 months well; the last 2 questions about pre-Q1 incidents required Slack history dives because no episodic entries cover that period" — gap + observed consequence
+  - Vague impact language like "this may affect quality" does NOT qualify — the consequence must be specific and already observed.
 - `recommendations`: Specific actions for the next maintenance cycle. If any recommendation would benefit all agents (not just this channel), prefix it with `[base-brain]`. Examples:
   - "Split semantic/projects.md into per-project files — currently 120 lines"
   - "[base-brain] Add guidance on deduplicating recurring morning-reflection topics to prevent agents repeating the same question across days"


### PR DESCRIPTION
## Summary

- Rewrites Section 3 ("Gap Analysis") of `skills/memory/reflect/skill.md` to require gap *and* concrete already-observed operational consequence.
- Routes gap-only observations to `processImprovements` as `[proposal]` instead of `observations`, so the observations list only carries entries that meet the criterion bar.
- Rewrites the `observations` examples in the JSON output spec — every gap example is now paired with a concrete already-observed consequence (3 duplicates, 4 inconsistent runs, Slack-history dives, …), so brains copy the pattern from examples.

## Why

`eval#135` remaining half: brains consistently self-assess `gap-impact-analysis` as PASS, but eval scorer scores FAIL. Latest run [25788113624](https://github.com/teamvibeai/poller-brain-eval/actions/runs/25788113624) shows 4/4 reflection reports from one brain disagreeing on this criterion.

The criterion ([criteria/criteria.json](https://github.com/teamvibeai/poller-brain-eval/blob/main/criteria/criteria.json)) requires:

> *passCondition:* At least one entry in observations identifies a specific memory gap AND explains how that gap caused a concrete problem or reduced maintenance effectiveness in recent cycles
>
> *scoringGuidance:* … "Core memory lacks project X context" alone does NOT qualify — that is a structural observation without impact. "Core memory lacks project X context, which caused 3 duplicate pattern entries in last week's consolidations" DOES qualify.

The current skill template invites gap-only observations:

- Section 3 reads _"Identify areas where memory is thin"_ with candidate classes ("frequently discussed topics with no semantic memory entry") — no requirement for consequence.
- All four `observations` JSON examples are either positive-strength or gap-only.

Brains follow the examples → produce gap-only observations → self-assess PASS (template doesn't say it's not enough) → eval correctly scores FAIL. Calibration drift was diagnosed in [eval#135's comment on PR #136](https://github.com/teamvibeai/poller-brain-eval/issues/135#issuecomment-4439729964) — not truncation, prompt under-specification.

## Discussion that led here

[vibe-keeper-brain Slack thread 2026-05-14](https://teamvibe.slack.com/) — Jakub picked direction 1 ("tighten the prompt, keep the criterion") over direction 2 (relax criterion) or 3 (retire criterion). Criterion is well-formed; the prompt was the weak link. J.A.R.V.I.S. reviewed and approved with two follow-up concerns now captured in the test plan below.

## Test plan

**Primary recovery validation:**
- [ ] Merge → next reflection cycle from any brain produces `reports/YYYY-MM-DD-memory-reflection.json` with observations that pair gap + consequence.
- [ ] Next daily eval run (`evals/2026-05-XX.json`) shows `gap-impact-analysis` PASS verdict for reflections after this lands.
- [ ] `selfAssessmentComparison.disagreements` for `gap-impact-analysis` drops to 0 for new reflection reports.

**Over-correction guard** (per J.A.R.V.I.S. review):
- Example ratio shifted from 1:3 (gap:strength) to 3:1. Brains copy patterns from examples, so there is a real risk the next reports flip to "all consequences, no strengths" — the opposite extreme.
- [ ] After 2–3 post-merge eval runs: average `observations` count per reflection report did not drop materially (compare to last 2 weeks' average).
- [ ] After 2–3 post-merge eval runs: at least 1 strength-style observation appears per reflection on healthy brains — observations are not 100% gap+consequence.

**Low-activity-brain follow-up** (per J.A.R.V.I.S. review, NOT part of this PR):
- Brains with no recent operational incident have nothing to cite as consequence. The routing rule sends gap-only entries to `processImprovements`, so `observations` may end up with 0 gap entries on a quiet brain — `gap-impact-analysis` then fails for the opposite reason (no qualifying entry, not bad writing).
- Separate eval-repo issue to introduce `n/a` verdict when 0 gap-class observations are present: filed on `poller-brain-eval` (link added once opened).

## Related

- [eval#135](https://github.com/teamvibeai/poller-brain-eval/issues/135) — original issue (truncation half fixed by [eval#136](https://github.com/teamvibeai/poller-brain-eval/pull/136))
- [eval#136](https://github.com/teamvibeai/poller-brain-eval/pull/136) — MAX_LIST_ITEMS bump (already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)