### PR TITLE
Base-brain: tagging recipients in shared threads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ This applies equally to **other agents** in the thread (they won't see your repl
 
 When you want to bring a *new* participant into the conversation, tag them explicitly even if they haven't spoken yet (e.g., `<@U...>` for second opinion / handoff / escalation).
 
+> Tool-layer guardrail tracking: [teamvibeai/teamvibe.ai#108](https://github.com/teamvibeai/teamvibe.ai/issues/108) (deterministic warning hint from `send_message`); thread-continuity wake: [teamvibeai/teamvibe.ai#109](https://github.com/teamvibeai/teamvibe.ai/issues/109).
+
 ## Persistent Storage
 
 If `$PERSISTENT_STORAGE_PATH` is set, you can use it for files that should persist across sessions (e.g., caches, downloaded tools). The `$PERSISTENT_STORAGE_PATH/bin` directory is in your PATH.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,18 @@ If `read_thread` fails, fall back to `read_channel` to get recent messages.
 - :memo: + "Saved to memory."
 - :white_check_mark: + "Done."
 
+### Tagging recipients in shared threads
+
+In shared threads (channel or group DM / `mpim`), tag the person you're responding to with `<@USER_ID>`. **Without a tag, the other party will not be notified** — other agents (bots) are only woken up by mentions, and humans frequently miss thread replies they're not tagged in.
+
+This applies equally to **other agents** in the thread (they won't see your reply until they're explicitly woken up) and to **humans** (they may not notice without a notification).
+
+**Quick rule:** if the last non-self message in the thread is from `<@X>` and your reply addresses or references it, your message should contain `<@X>`.
+
+**Exception — 1:1 DM (`im` channel type):** don't tag. There's only one other party and the tag is noise.
+
+When you want to bring a *new* participant into the conversation, tag them explicitly even if they haven't spoken yet (e.g., `<@U...>` for second opinion / handoff / escalation).
+
 ## Persistent Storage
 
 If `$PERSISTENT_STORAGE_PATH` is set, you can use it for files that should persist across sessions (e.g., caches, downloaded tools). The `$PERSISTENT_STORAGE_PATH/bin` directory is in your PATH.


### PR DESCRIPTION
## Summary

Adds a Response Guidelines subsection telling agents to `<@tag>` the recipient of their reply in multi-party threads (channel / group DM), with a 1:1 DM exception.

## Why

Multi-agent threads frequently stall because agents forget to tag each other when replying. Without a mention, other bots aren't woken up and humans often miss the notification — the conversation silently dies until someone re-pings.

Discussion: Jakub ↔ VibeKeeper ↔ Jarvis on 2026-05-17. Channel-type gate (`im` = no tag, `mpim`/`channel` = tag) finalized by Jakub.

## Rule (added under Response Guidelines)

> In shared threads (channel or group DM / `mpim`), tag the person you're responding to with `<@USER_ID>`. Without a tag, the other party will not be notified — other agents (bots) are only woken up by mentions, and humans frequently miss thread replies they're not tagged in.
>
> Quick rule: if the last non-self message in the thread is from `<@X>` and your reply addresses or references it, your message should contain `<@X>`.
>
> Exception — 1:1 DM (`im` channel type): don't tag.

## Two-layer fix

This is the **LLM-side** layer. LLM compliance is nestabilní (viz opakované regrese typu MEM-6, MEM-7), takže pravidlo samo o sobě 100 % nestačí. Tool-layer guardrail (deterministic warning hint v `send_message` + thread participant exposure v session contextu) je sledována v [teamvibeai/teamvibe.ai#108](https://github.com/teamvibeai/teamvibe.ai/issues/108). Komplement [teamvibeai/teamvibe.ai#109](https://github.com/teamvibeai/teamvibe.ai/issues/109) řeší thread-continuity wake.

## Test plan

- [ ] Reviewer scans diff (12 lines added under Response Guidelines)
- [ ] Sanity check: rule matches "base-brain belongs" criteria — Slack communication mechanic, universal across workspaces ✓
- [ ] Merge → rolls out to all pollers on next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)