### PR TITLE
Auto-improve: daily-log-weekly-coverage

### DIFF
--- a/skills/memory/scripts/log-write.ts
+++ b/skills/memory/scripts/log-write.ts
@@ -19,10 +19,19 @@ import * as path from "path";
 const TODAY_PATH = "memory/TODAY.md";
 
 function ensureToday(): void {
+  const today = new Date().toISOString().slice(0, 10);
+
   if (!fs.existsSync(TODAY_PATH)) {
     fs.mkdirSync(path.dirname(TODAY_PATH), { recursive: true });
-    const today = new Date().toISOString().slice(0, 10);
     fs.writeFileSync(TODAY_PATH, `# ${today}\n\n`);
+    return;
+  }
+
+  // If TODAY.md exists but lacks today's date section, prepend one so entries are
+  // filed under the correct date when consolidation archives the file to daily/.
+  const content = fs.readFileSync(TODAY_PATH, "utf8");
+  if (!content.includes(`# ${today}`)) {
+    fs.writeFileSync(TODAY_PATH, `# ${today}\n\n` + content);
   }
 }
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** daily-log-weekly-coverage
**Eval date:** 2026-05-13
**Overall score:** 0.875

### Recent Eval History
- actionable-recommendations: 100%
- assess-memory-quality: 100%
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 100%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 93% <-- TARGET
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 86%
- meaningful-decisions: 100%
- no-data-loss: 100%
- no-summary-manual-edit: 98%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 98%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 94%
- today-md-archived: 95%
- update-relevant-tiers: 100%
- verifiable-recommendations: 86%

### What Changed
## Improvement Summary

**Target criterion:** daily-log-weekly-coverage
**Files modified:** skills/memory/scripts/log-write.ts

### What changed

`ensureToday()` previously only created `memory/TODAY.md` when the file was absent. If the file existed with a stale date header (e.g., `# 2026-05-04` when today is `2026-05-11`), log entries were silently appended under the old date section. When consolidation ran and archived TODAY.md, all those entries landed in `memory/daily/2026-05-04.md` — the session days (2026-05-05 through 2026-05-11) showed no daily log, reducing the coverage ratio below 0.8.

The fix: after confirming the file exists, `ensureToday()` reads the file and checks whether today's date section (`# YYYY-MM-DD`) is already present. If not, it prepends a fresh date section at the top. Consolidation Step 0 already handles multi-section TODAY.md files by archiving each `# YYYY-MM-DD` section to its own `memory/daily/YYYY-MM-DD.md` file, so the archived logs will land on the correct dates.

### Report insights influence

The change directly implements the recommendation from report-insights.md:
> "Consider having log-write.ts detect a stale TODAY.md date header (older than today) and start a fresh dated section instead of appending under the old header — this brain has hit the misfiled-entry pattern twice in 8 days (2026-05-05 onboarding, 2026-05-11 tiketo-pass-share kickoff)"

### Skill Impact

**Skill:** memory/scripts/log-write.ts — appends timestamped entries to `memory/TODAY.md` for routine session logging.

**Behavior change:** When a log entry is written on a day where TODAY.md exists but carries a header from a previous day, the script now prepends a new `# YYYY-MM-DD` section before appending. Entries written after the day-rollover will be correctly filed under today's date section, and consolidation will archive them to `memory/daily/<today>.md` rather than misfiling them under the old date.

### Expected impact

Eliminates the misfiled-entry pattern that caused session days to appear as "no daily log" in the coverage calculation. The coverage ratio (`days_with_daily_log / days_with_any_session`) should reach or exceed 0.8 consistently, improving the `daily-log-weekly-coverage` pass rate from the current 50% toward the historical average of ~93%.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*