### PR TITLE
Sync eval criteria tables from criteria.json

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -166,13 +166,15 @@ These criteria are used for self-assessment in the JSON report's `selfAssessment
 
 ## Context' or '## Kontext' with at least one line of text below it. This ensures reference files explain why they exist. If no new session-capture files were created, pass automatically. |
 
+## Context' or '## Kontext' with at least one line of text below it. This ensures reference files explain why they exist. If no new session-capture files were created, pass automatically. |
+
 ### Reflection Criteria
 
 | ID | Criterion | Pass condition |
 |----|-----------|----------------|
 | `concrete-improvement-proposal` | Did reflection produce at least one concrete process change proposal? | Report includes at least one specific proposal for changing the maintenance process, with a stated rationale (what should change and why), not merely an observation that something is broken |
 | `previous-recommendations-reviewed` | Did reflection review follow-through on previous recommendations? | Report explicitly references at least one recommendation from a prior maintenance cycle and states whether it was implemented, partially addressed, or remains pending |
-| `gap-impact-analysis` | Did reflection connect at least one memory gap to a specific operational consequence? | At least one entry in observations identifies a specific memory gap AND explains how that gap caused a concrete problem or reduced maintenance effectiveness in recent cycles |
+| `gap-impact-analysis` | Did reflection connect at least one memory gap to a specific operational consequence? | At least one entry in observations identifies a specific memory gap AND explains how that gap caused a concrete problem or reduced maintenance effectiveness in recent cycles. Per-report applicability: if observations contains zero gap-class entries (no language like 'lacks', 'missing', 'thin', 'no entry for', 'gap in coverage'), the report is excluded from scoring (treated as not-applicable for this criterion). The criterion only evaluates reports where at least one gap-class observation is present after the poller-brain#95 routing rule moves gap-only entries to processImprovements. |
 | `verifiable-recommendations` | Did reflection include at least one recommendation with a stated success criterion? | At least one entry in recommendations specifies: (1) a concrete change to make, (2) the current problem it addresses, AND (3) a verifiable condition that would confirm the recommendation was implemented and effective in a future maintenance cycle |
 | `deletion-with-preservation-evidence` | Did reflection explicitly account for each deleted file's content preservation? | For every file deletion recorded in filesChanged (operationCounts.deleted > 0): the report names in decisions or observations the specific destination file where the deleted content was preserved, OR explicitly states the content was redundant with a specifically named existing file. If operationCounts.deleted is 0, the criterion passes automatically. |
 


### PR DESCRIPTION
## Criteria Sync

This is an automated sync of the eval criteria tables in MAINTENANCE.md from the canonical `criteria/criteria.json` in the eval repo.

### Current Criteria
Active criteria: 20
  - reduce-log-count: At least one daily log was processed/archived
  - update-relevant-tiers: Changes propagated to appropriate tier (daily -> core, daily
  - process-self-critique: Report contains at least one entry questioning whether the c
  - concrete-improvement-proposal: Report includes at least one specific proposal for changing 
  - previous-recommendations-reviewed: Report explicitly references at least one recommendation fro
  - daily-log-exists-today: If any session ran today (commits, reports, or MCP activity 
  - daily-log-continuous-appends: Today's daily log (or the most recent day with 2+ sessions) 
  - daily-log-recent-retention: After consolidation completes, memory/daily/<today>.md and m
  - daily-log-weekly-coverage: Over the last 7 days, days_with_daily_log / days_with_any_se
  - evidence-backed-decisions: At least 2 entries in the decisions array reference specific
  - gap-impact-analysis: At least one entry in observations identifies a specific mem
  - verifiable-recommendations: At least one entry in recommendations specifies: (1) a concr
  - deletion-with-preservation-evidence: For every file deletion recorded in filesChanged (operationC
  - summary-md-regenerated: memory/SUMMARY.md appears in filesChanged, indicating the co
  - today-md-archived: memory/TODAY.md appears in filesChanged, indicating the dail
  - at-imports-configured: The consolidation report's Daily Log Compliance section or s
  - no-summary-manual-edit: Between consolidation runs, memory/SUMMARY.md was only modif
  - session-capture-logged: For every regular-session commit that created or modified a 
  - semantic-naming-convention: All files created in memory/semantic/ since the last consoli
  - session-capture-has-context: Every file created in memory/semantic/ during regular sessio

### What Changed
The Consolidation Criteria and/or Reflection Criteria tables in the Eval Criteria section of MAINTENANCE.md have been updated to match the current criteria.json registry.

---
*Auto-generated by sync-criteria workflow. This PR can be auto-merged (mechanical sync per D-11).*