### PR TITLE
Auto-improve: daily-log-weekly-coverage

### DIFF
--- a/skills/memory/scripts/log-write.ts
+++ b/skills/memory/scripts/log-write.ts
@@ -19,10 +19,18 @@ import * as path from "path";
 const TODAY_PATH = "memory/TODAY.md";
 
 function ensureToday(): void {
+  const today = new Date().toISOString().slice(0, 10);
   if (!fs.existsSync(TODAY_PATH)) {
     fs.mkdirSync(path.dirname(TODAY_PATH), { recursive: true });
-    const today = new Date().toISOString().slice(0, 10);
     fs.writeFileSync(TODAY_PATH, `# ${today}\n\n`);
+    return;
+  }
+  // If the most recent date header is older than today, start a fresh section
+  // so entries are logged under the correct date (prevents misfiled-entry pattern)
+  const content = fs.readFileSync(TODAY_PATH, "utf-8");
+  const headerMatch = content.match(/^# (\d{4}-\d{2}-\d{2})/m);
+  if (!headerMatch || headerMatch[1] !== today) {
+    fs.appendFileSync(TODAY_PATH, `\n# ${today}\n\n`);
   }
 }
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** daily-log-weekly-coverage
**Eval date:** 2026-05-13
**Overall score:** 0.875

### Recent Eval History
- actionable-recommendations: 100%
- assess-memory-quality: 100%
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 100%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 93% <-- TARGET
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 86%
- meaningful-decisions: 100%
- no-data-loss: 100%
- no-summary-manual-edit: 98%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 98%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 94%
- today-md-archived: 95%
- update-relevant-tiers: 100%
- verifiable-recommendations: 86%

### What Changed
## Improvement Summary

**Target criterion:** daily-log-weekly-coverage
**Files modified:** skills/memory/scripts/log-write.ts

### What changed

Added stale date-header detection to `ensureToday()` in log-write.ts. Previously, if `memory/TODAY.md` existed with a date header from a prior day, `log-write.ts` would append new entries under that old header instead of starting a fresh section for today. Now, when the script runs and finds a date header older than today, it appends a new `# YYYY-MM-DD` section before logging — ensuring each entry lands under the correct day.

### Why

The report-insights.md flagged this exact pattern: "this brain has hit the misfiled-entry pattern twice in 8 days (2026-05-05 onboarding, 2026-05-11 tiketo-pass-share kickoff)". When entries are logged under the wrong day's header, the daily-log-weekly-coverage metric can undercount days that actually had session activity, causing the coverage ratio to appear lower than it truly is and failing the criterion.

The report-insights.md recommendation was: "Consider having log-write.ts detect a stale TODAY.md date header (older than today) and start a fresh dated section instead of appending under the old header."

### Skill Impact

**Skill:** memory/scripts/log-write.ts — appends routine log entries to memory/TODAY.md  
**Behavior change:** `ensureToday()` now reads the existing file and checks whether the most recent `# YYYY-MM-DD` header matches today. If it doesn't (day rollover occurred without a consolidation reset), a new dated section is appended before the log entry. Entries will no longer be misfiled under a stale date, giving accurate per-day coverage counts.

### Expected impact

Eliminates the misfiled-entry pattern that causes daily logs to be attributed to the wrong date. The daily-log-weekly-coverage scorer will see a log entry under the correct date for each day with activity, improving the pass rate from the current 50% toward the historical average of 93%.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*