### PR TITLE
Auto-improve: daily-log-weekly-coverage

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -414,6 +414,8 @@ If any check fails, do one of two things before finishing:
 
 **Weekly coverage special rule:** if coverage is < 0.8 and backfill cannot raise it to ≥ 0.8, you MUST add a `[self-critique]` entry to `processImprovements` that names the specific days that had sessions but no log and explains what happened. Reporting a low ratio without this entry fails the criterion. The self-critique does NOT replace the ratio in the markdown — both are required when coverage is low.
 
+Example low-coverage self-critique: `"[self-critique] Coverage 3/7 (43%): sessions on 2026-05-17, 2026-05-18, 2026-05-20 had no daily log because TODAY.md was archived as a single cross-day file (2026-05-10.md) covering entries from multiple dates. Entries correctly dated but per-day files missing. Will ensure per-day archival going forward."`
+
 Do not silently pass a failing check.
 
 ### 11. Process Self-Critique

--- a/skills/memory/scripts/log-write.ts
+++ b/skills/memory/scripts/log-write.ts
@@ -25,11 +25,13 @@ function ensureToday(): void {
     fs.writeFileSync(TODAY_PATH, `# ${today}\n\n`);
     return;
   }
-  // If the most recent date header is older than today, start a fresh section
-  // so entries are logged under the correct date (prevents misfiled-entry pattern)
+  // If the LAST date header is older than today, start a fresh section
+  // so entries are logged under the correct date (prevents misfiled-entry pattern).
+  // Must check LAST header (not first) to avoid duplicate sections on same-day calls.
   const content = fs.readFileSync(TODAY_PATH, "utf-8");
-  const headerMatch = content.match(/^# (\d{4}-\d{2}-\d{2})/m);
-  if (!headerMatch || headerMatch[1] !== today) {
+  const headers = [...content.matchAll(/^# (\d{4}-\d{2}-\d{2})/gm)];
+  const lastHeader = headers[headers.length - 1];
+  if (!lastHeader || lastHeader[1] !== today) {
     fs.appendFileSync(TODAY_PATH, `\n# ${today}\n\n`);
   }
 }


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** daily-log-weekly-coverage
**Eval date:** 2026-05-23
**Overall score:** 0.9462

### Recent Eval History
- actionable-recommendations: 100%
- assess-memory-quality: 100%
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 100%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 79% <-- TARGET
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 86%
- meaningful-decisions: 100%
- no-data-loss: 100%
- no-summary-manual-edit: 100%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 98%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 94%
- today-md-archived: 96%
- update-relevant-tiers: 99%
- verifiable-recommendations: 86%

### What Changed
## Improvement Summary

**Target criterion:** daily-log-weekly-coverage
**Files modified:**
- `skills/memory/scripts/log-write.ts`
- `skills/memory/consolidate/skill.md`

### What changed

**1. Fixed stale-header bug in log-write.ts (introduced by cffb04c)**

The previous improvement (cffb04c) added stale date-header detection but checked the **first** date header in TODAY.md instead of the **last**. Since TODAY.md accumulates multiple date sections over time, the first header is always the oldest reset date — so every subsequent log-write call on the same day found a stale first header and appended a duplicate `# YYYY-MM-DD` section. Changed to use `matchAll` to find the **last** date header before deciding whether to append a new section.

**2. Added concrete [self-critique] example to consolidation Step 10**

The scoring guidance for `daily-log-weekly-coverage` requires that when coverage < 0.8, `processImprovements` must contain a `[self-critique]` entry that **names specific missing days and explains what happened**. The skill had the rule but no example, leaving the format ambiguous. Added an explicit example showing the exact structure (ratio, specific dates, root cause, corrective intent) the scorer expects.

### Root cause (from report-insights.md)

Report 01KN4BZX8K4JE32R42R8S75KRB explicitly observed: "Daily log coverage in this brain is structurally fragile because TODAY.md accumulates entries under a single date header for multiple days… Without backfill this cycle's coverage would have been 4/7." The report recommended "Avoid cross-day single-file archives: when archiving TODAY.md with entries from multiple dates, write to per-day daily/YYYY-MM-DD.md files."

The log-write.ts fix ensures per-day date sections are created correctly (no duplicates, no stale-header false-positive), which in turn means consolidation Step 0 can archive each section to its own `daily/YYYY-MM-DD.md` file.

### Skill Impact

**Skill:** `memory/scripts/log-write.ts` — appends entries to `memory/TODAY.md`
**Behavior change:** The script now checks the **last** date header in TODAY.md (instead of the first) before deciding whether to append a new date section. Same-day calls no longer create duplicate `# YYYY-MM-DD` headers, and the stale-header detection works correctly when TODAY.md already contains multiple date sections.

**Skill:** `memory/consolidate` — Step 10 (Assess Daily Log Compliance)
**Behavior change:** When coverage < 0.8, the brain now has a concrete example of what the required `[self-critique]` entry should contain (ratio, specific missing dates, root cause, corrective action). This reduces the chance of a generic or vague self-critique that doesn't satisfy the scorer's "names the gap and explains what happened" requirement.

### Expected impact

- The log-write.ts fix prevents the duplicate-header problem that causes multiple date sections to compress back to single-file archives during consolidation. Future TODAY.md files will have clean per-day sections → consolidation archives to correct per-day files → coverage ratios in reports improve toward ≥ 0.8.
- The concrete [self-critique] example ensures that even when coverage is genuinely low (e.g., after a consolidation gap), the criterion still passes because the report correctly documents the gap. This directly addresses the fail mode where coverage < 0.8 reports had no qualifying self-critique.
- Expected improvement: from 0.0 toward the historical average (0.786) and above.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*