### PR TITLE
Brevity rules for maintenance report narrative fields (#104)

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -123,11 +123,11 @@ The JSON file is written at the same time as the markdown report, in the same co
 | `operationType` | `string` | One of: `consolidation`, `reflection` |
 | `operationCounts` | `object` | Count of files created, modified, deleted |
 | `filesChanged` | `string[]` | Relative paths of all files changed |
-| `decisions` | `string[]` | Plain-text list of decisions made during this run |
-| `observations` | `string[]` | Specific observations about memory quality, strengths, or gaps (used by `assess-memory-quality` criterion) |
-| `recommendations` | `string[]` | Actionable recommendations for the next maintenance cycle (used by `actionable-recommendations` criterion) |
+| `decisions` | `string[]` | Plain-text list of decisions made during this run. **One sentence per item, action-first phrasing (verb + object + minimal evidence). Cap at 5 items.** When a criterion (e.g. `evidence-backed-decisions`) requires a specific memory file or count, name it inline — do not narrate the discovery process. |
+| `observations` | `string[]` | Specific observations about memory quality, strengths, or gaps (used by `assess-memory-quality` criterion). **One sentence per item, fact-first (the observation itself, not how you found it). Cap at 5 items.** |
+| `recommendations` | `string[]` | Actionable recommendations for the next maintenance cycle (used by `actionable-recommendations` criterion). **Imperative, one sentence per item. Include success criterion inline when required (see `verifiable-recommendations`). Cap at 5 items.** |
 | `selfAssessment` | `object` | Boolean pass/fail per eval criterion (see Eval Criteria below) |
-| `processImprovements` | `string[]` | Self-critique and proposals for process improvement. Each entry must be prefixed with `[self-critique]`, `[proposal]`, or `[blocked]`. At least one entry required per reflection. |
+| `processImprovements` | `string[]` | Self-critique and proposals for process improvement. Each entry must be prefixed with `[self-critique]`, `[proposal]`, or `[blocked]`. At least one entry required per reflection. **One sentence per item after the prefix. Cap at 5 items.** |
 | `pendingIssues` | `object[]` | Issues reported by users for creation on GitHub. Each object: `repo` (target repository), `title`, `context` (user's description), `reportedBy` (who reported), `date`. Empty array or omitted if none. See Pending Issues section below. |
 | `heartbeatStatus` | `object` | Self-reported state of the brain's `HEARTBEAT.md` file at consolidation time. `present` (bool): file exists. `nonEmpty` (bool): file contains at least one line that is not blank, a heading, an HTML comment, or a completed `- [x]` task. `itemCount` (int): number of unchecked task lines (`- [ ]`). Used by eval pipeline to track heartbeat deprecation progress (`teamvibeai/teamvibe.ai#102`). |
 | `brainCommitSha` | `string` | Output of `git rev-parse HEAD` at the time of the report |
@@ -137,6 +137,7 @@ The JSON file is written at the same time as the markdown report, in the same co
 - The `selfAssessment` keys MUST match the criterion IDs defined in the Eval Criteria section below.
 - The JSON file MUST be valid JSON (no trailing commas, no comments).
 - Commit the JSON report in the same commit as the markdown report and the maintenance changes.
+- **Brevity: each item in `decisions` / `observations` / `recommendations` / `processImprovements` is ONE sentence (max ~200 chars). Cap each list at 5 items.** Reports are read by both humans and the eval pipeline — terse, fact-first writing scales; verbose narration does not. Reasoning belongs in the markdown report's Decisions section, NOT the JSON. If a criterion needs a specific evidence reference (e.g. a memory filename, a count), name it inline; do not describe the discovery process. The markdown report can still narrate in full — only the JSON list items need to be terse.
 
 ## Eval Criteria
 


### PR DESCRIPTION
Closes #104.

## Summary

- One sentence per item, cap at 5 items, in `decisions` / `observations` / `recommendations` / `processImprovements`.
- Discovery-process narration moves to the markdown report only.
- Evidence references (memory filenames, counts) MUST stay inline so eval criteria still pass.

## Why

Post-poller-brain#101 recovery pushed fleet maintenance volume from ~10 to 42 reports/day (2026-05-23). The eval pipeline timed out at the 20-min scoring budget. Per-field analysis of today's 20 trimmed reports:

| Field | Total bytes | % |
|---|---|---|
| decisions | 17.6 KB | 23% |
| observations | 14.8 KB | 19% |
| processImprovements | 14.2 KB | 19% |
| recommendations | 11.4 KB | 15% |
| selfAssessment | 9.6 KB | 13% |
| filesChanged | 6.0 KB | 8% |
| envelope | — | 3% |

76% of bytes live in the 4 narrative arrays. Current items run 1-3 sentences with full rationale — that load multiplies by N criteria × M reports inside the eval pipeline.

Three downstream patches landed today on `poller-brain-eval` to survive 42 reports/day:
- [`c8c1433`](https://github.com/teamvibeai/poller-brain-eval/commit/c8c1433) — warn-only drift gate
- [`89413f7`](https://github.com/teamvibeai/poller-brain-eval/commit/89413f7) — operationType pre-filter (-38% Claude input)
- [`0f88423`](https://github.com/teamvibeai/poller-brain-eval/commit/0f88423) — concurrency 3→6 + timeout 20→30

Those are symptom patches. **This PR is the upstream root-cause fix.** Per Jakub's call on Slack 2026-05-23: *„prijde mi, ze ty reporty musime zmensit (aby pollery posilali uz mensi)\"*.

## Test plan

- [ ] Merge and let the next consolidation cycle pick up the change (auto-update ~1 day).
- [ ] Pull a fresh maintenance report from any brain after auto-update lands; confirm trimmed JSON size drops to ~2-3 KB median (currently ~4-5 KB).
- [ ] Verify eval pipeline scoring still produces non-`not_applicable` verdicts on criteria that depend on evidence content (`evidence-backed-decisions`, `verifiable-recommendations`, `gap-impact-analysis`).
- [ ] Watch `poller-brain-eval` Run 1 after rollout: scoring step wall-clock should drop further.

## Risk

- *Discoverability of evidence:* mitigated by the explicit "name it inline" rule.
- *Loss of self-critique depth:* `processImprovements` is the most narrative-heavy field. Capping at 5 × 1-sentence may hide secondary critiques. Acceptable trade for routine ops; reflections retain the markdown body for depth.

## Tier

Tier 2 (process / prompt change touching the entire fleet). Tagging Jakub for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)