### PR TITLE
Auto-improve: daily-log-weekly-coverage

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -26,6 +26,8 @@ Before processing, archive `memory/TODAY.md` to the daily/ directory:
 1. Read `memory/TODAY.md` — extract the date header(s) (format: `# YYYY-MM-DD`)
 2. For each date section in TODAY.md:
    - Append its content **verbatim** to `memory/daily/YYYY-MM-DD.md` (create if needed). Copy every bullet point and line exactly as written — do NOT summarize, truncate, rephrase, or condense entries. The daily archive must be a byte-for-byte copy of the original content.
+   - **⚠️ Multiple date sections → multiple files (required).** If TODAY.md contains sections `# 2026-05-15`, `# 2026-05-16`, `# 2026-05-17`, you MUST create three separate files: `daily/2026-05-15.md`, `daily/2026-05-16.md`, `daily/2026-05-17.md`. Do NOT archive all sections into a single file — that silently fails `daily-log-weekly-coverage` because only the first date gets a log file while all other session days are invisible to the evaluator.
+   - If TODAY.md has entries but no date header at all, assign them to today's date and archive to `memory/daily/<today>.md`.
 3. Reset `memory/TODAY.md` with today's date header and an immediate consolidation log entry:
    ```
    # YYYY-MM-DD


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** daily-log-weekly-coverage
**Eval date:** 2026-05-24
**Overall score:** 0.9411

### Recent Eval History
- actionable-recommendations: 100%
- assess-memory-quality: 100%
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 100%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 71% <-- TARGET
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 81%
- meaningful-decisions: 100%
- no-data-loss: 100%
- no-summary-manual-edit: 100%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 98%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 89%
- today-md-archived: 97%
- update-relevant-tiers: 99%
- verifiable-recommendations: 86%

### What Changed
## Improvement Summary

**Target criterion:** daily-log-weekly-coverage
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Added an explicit anti-pattern warning to Step 0 (Archive TODAY.md), item 2 of the consolidation skill. The new sub-bullet makes it unambiguous that when TODAY.md spans multiple date sections, each section MUST be archived to its own per-day file — not collapsed into a single file under the first date header.

Also added a fallback rule: if TODAY.md has entries but no date header at all, assign them to today's date.

### Why

The `daily-log-weekly-coverage` criterion scores `days_with_daily_log / days_with_any_session` over the last 7 days. Multiple consolidation reports confirmed the root cause: brains were archiving TODAY.md as a single cross-day file (e.g., everything into `daily/2026-05-04.md`) even when TODAY.md held entries spanning two weeks. This left every session day except the first without a daily log file, silently tanking coverage from 100% to ~14%.

The report insights explicitly identified this: "Daily log coverage in this brain is structurally fragile because TODAY.md accumulates entries under a single date header for multiple days. The previous consolidation chose a single cross-day archive covering 2026-05-04 → 2026-05-19, which silently fails the per-day eval criterion."

The existing instruction said "For each date section in TODAY.md" but did not explicitly forbid the single-file pattern or explain why it breaks coverage.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure run during maintenance heartbeat
**Behavior change:** Step 0 now explicitly requires one `memory/daily/YYYY-MM-DD.md` file per date section in TODAY.md. Brains that previously archived multi-date TODAY.md content into a single file will now correctly produce per-day archive files, ensuring each session day is independently visible to the coverage evaluator.

### Expected impact

Brains with multi-day TODAY.md accumulation (the most common failure mode) will now produce correct per-day archives during consolidation. This should raise `daily-log-weekly-coverage` from the current 0.5 (latest) / 0.71 (historical avg) toward the target of ≥ 0.8.

### Report insights influence

The change directly implements the recommendation from consolidation report `01KN4BZX8K4JE32R42R8S75KRB`: "Avoid cross-day single-file archives: when archiving TODAY.md with entries from multiple dates, write to per-day daily/YYYY-MM-DD.md files."

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*