### PR TITLE
skill(consolidate): drop Step 8 timestamp write (poller owns it since v0.4.3)

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -266,14 +266,7 @@ For daily log files (format: `YYYY-MM-DD.md`) in `memory/daily/` that are older 
 
 **Recent-log retention (non-negotiable):** NEVER delete `memory/daily/<today>.md` or `memory/daily/<yesterday>.md`, regardless of whether their contents have been promoted. Same-day and next-day sessions rely on these files to recover context. Promotion is not a reason to delete; deletion is only for files dated 30+ days ago.
 
-### 8. Update Timestamp
-
-Write the current date to `memory/.last_consolidation`:
-```
-YYYY-MM-DD
-```
-
-### 8b. Heartbeat Sweep & Self-Report
+### 8. Heartbeat Sweep & Self-Report
 
 Heartbeat is being deprecated (`teamvibeai/teamvibe.ai#102`). Channel brain repos are private and live in customer GH orgs — the platform cannot inspect them. Each brain MUST self-report `HEARTBEAT.md` state so the eval pipeline can track migration progress.
 


### PR DESCRIPTION
## Summary

Step 8 of the consolidation skill used to instruct the LLM to write today's date to \`memory/.last_consolidation\`. Since \`teamvibeai/teamvibe.ai#128\` (poller v0.4.3+), the poller's \`MaintenanceReporter\` writes that file automatically after a successful event POST — success-gated by design (see #128 for why).

@jakubknejzlik flagged that the skill shouldn't be carrying platform-internal mechanics or warnings about them — *"proč to vůbec zmiňujeme? Vůbec bych tím brain v rámci maintenance nezatěžoval."* So this PR **drops Step 8 entirely**, no replacement warning, and renumbers 8b → 8.

## The change

- Delete \`### 8. Update Timestamp\` (the write instruction).
- Rename \`### 8b. Heartbeat Sweep & Self-Report\` → \`### 8. Heartbeat Sweep & Self-Report\`.
- Net: 1 insertion, 8 deletions.

Step 1 of this skill still **reads** \`.last_consolidation\` to determine which daily logs to process — unchanged. The poller-side write owns the file going forward.

## Risk

Zero — pure markdown trim. No logic, no behavior change in the brain. Pre-v0.4.3 brains have already proven the file can stay stale without breaking anything except the metric (which #128 now fixes platform-side).

## Refs

- \`teamvibeai/teamvibe.ai#128\` (poller-side hook, merged \`f97e00d\`)
- \`teamvibeai/poller-brain-eval#150\` (root-cause paper trail)
- \`teamvibeai/poller-brain#109\` (closed)

Tier 1 — self-merge per [MEM-1] after force-push lands.