### PR TITLE
Auto-improve: summary-md-regenerated

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -238,6 +238,8 @@ If `memory/semantic/` doesn't exist or is empty, skip this step and set `selfAss
 
 **Always regenerate `memory/SUMMARY.md` on every consolidation run — this step is non-negotiable, even if no facts were promoted in steps 2–4.** A lightweight consolidation with zero promotions must still regenerate SUMMARY.md to ensure it reflects the current state of all memory tiers.
 
+**Mandatory timestamp:** The first line of SUMMARY.md (before all sections) MUST be updated to `**Last consolidated:** YYYY-MM-DD HH:MM UTC` with the current date and time. This timestamp guarantees the file always differs from its previous version — eliminating the silent-skip risk when memory content is unchanged. Even on a zero-promotion run, the timestamp must be freshened. A SUMMARY.md with a stale "Last consolidated" line from a prior run means Step 6 did not execute.
+
 Read all `memory/core/*.md`, scan `memory/semantic/`, `memory/episodic/`, `memory/procedural/` for file listing, and compile into the SUMMARY.md format defined in the memory skill. Target ~100-150 lines.
 
 Key sections:

--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -366,6 +366,8 @@ When you need context beyond core/ and daily logs:
 
 Structure:
 ```markdown
+**Last consolidated:** YYYY-MM-DD HH:MM UTC
+
 ## How this memory works
 - This file (SUMMARY.md) and TODAY.md are `@`-imported into every session — they are always in your context
 - All other memory files (core/, semantic/, episodic/, procedural/) must be actively read via tools


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** summary-md-regenerated
**Eval date:** 2026-05-26
**Overall score:** 0.95

### Recent Eval History
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 96%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 52%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 74%
- meaningful-decisions: 100%
- no-data-loss: 100%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 97%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 80% <-- TARGET
- today-md-archived: 98%
- update-relevant-tiers: 99%
- verifiable-recommendations: 82%

### What Changed
## Improvement Summary

**Target criterion:** summary-md-regenerated
**Files modified:**
- `skills/memory/consolidate/skill.md`
- `skills/memory/skill.md`

### What changed

Added a mandatory `**Last consolidated:** YYYY-MM-DD HH:MM UTC` timestamp to the top of `memory/SUMMARY.md` (defined in the SUMMARY.md format template in `skills/memory/skill.md`).

In `skills/memory/consolidate/skill.md` Step 6, added an explicit instruction that this timestamp MUST be updated on every consolidation run, with the rationale: even on zero-promotion runs, the timestamp ensures the file always differs from its previous version — eliminating the silent-skip risk.

### Root cause addressed

The criterion fails when `memory/SUMMARY.md` does not appear in `filesChanged`. On "quiet" consolidation days with no memory changes, brains were silently treating SUMMARY.md as an idempotent no-op (regenerated content identical to prior run → not recorded in filesChanged). One brain explicitly flagged this in a maintenance report: *"Consider proposing a base-brain change so summary-md-regenerated passes when no semantic content changed AND SUMMARY.md is still current."*

Rather than changing the criterion, this fix eliminates the idempotency problem at the source: a timestamp that changes every run makes SUMMARY.md always need writing.

### Expected impact

The `summary-md-regenerated` pass rate should improve from 0.6667 toward 1.0. Every consolidation run that properly executes Step 6 will now produce a SUMMARY.md with a new timestamp, making it unambiguously present in filesChanged.

### Skill Impact

**Skill:** `memory/consolidate` — Memory consolidation procedure executed during maintenance heartbeat

**Behavior change:** Step 6 now requires writing a `Last consolidated: YYYY-MM-DD HH:MM UTC` line at the top of SUMMARY.md before all sections. The instruction explicitly states that a stale timestamp from a prior run is evidence Step 6 did not execute — reinforcing the non-negotiable nature of this step even on zero-promotion runs.

**Skill:** `memory` — Memory system documentation including SUMMARY.md format template

**Behavior change:** The SUMMARY.md format template now shows `**Last consolidated:** YYYY-MM-DD HH:MM UTC` as the first line, so brains generating SUMMARY.md from the template will include this field by default.

### Report insights influence

The fix directly addresses the recommendation from consolidation report `01KKVN3QNQ9TYFW3XBANV08HAA`: *"Consider proposing a base-brain change so summary-md-regenerated passes when no semantic content changed AND SUMMARY.md is still current (no-op idempotent passes)."* Instead of changing the criterion definition, the fix makes the idempotent case impossible by design.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*