### PR TITLE
fix(skills/slack): raw_number cell requires both `value` AND `text` fields

### DIFF
--- a/skills/slack/skill.md
+++ b/skills/slack/skill.md
@@ -107,7 +107,14 @@ Reference: [markdown block](https://docs.slack.dev/reference/block-kit/blocks/ma
 
 ### `data_table` block — large or interactive datasets
 
-Use when the user needs **sort, filter, or pagination** over structured data, or when the dataset is too large for a comfortable inline GFM table. Required fields: `caption` (string), `rows` (array). Optional: `page_size` (1–100, default 5), `row_header_column_index` (default 0). Cell types: `raw_text` (string), `raw_number` (numeric, enables numeric sort), `rich_text` (header cells only). Constraints: 2–101 rows, 1–20 columns, 10,000-character total across all cells.
+Use when the user needs **sort, filter, or pagination** over structured data, or when the dataset is too large for a comfortable inline GFM table. Required fields: `caption` (string), `rows` (array). Optional: `page_size` (1–100, default 5), `row_header_column_index` (default 0).
+
+**Cell types:**
+- `raw_text` — fields: `type`, `text` (string).
+- `raw_number` — fields: `type`, `value` (number, used for numeric sort), `text` (string, the displayed label). **Both `value` and `text` are required** — sending `raw_number` with only one is rejected by Slack as `invalid_blocks` (verified empirically against `chat.postMessage` 2026-05-27).
+- `rich_text` — header cells only; standard rich_text block structure (sections, lists, links, mentions).
+
+Constraints: 2–101 rows, 1–20 columns, 10,000-character total across all cells.
 
 ```json
 {
@@ -126,7 +133,7 @@ Use when the user needs **sort, filter, or pagination** over structured data, or
         [
           { "type": "raw_text", "text": "INC-742" },
           { "type": "raw_text", "text": "P1" },
-          { "type": "raw_number", "value": 47 }
+          { "type": "raw_number", "value": 47, "text": "47" }
         ]
       ]
     }


### PR DESCRIPTION
Fix for broken example shipped in #132 (commit 6148dfc).

## Empirical verification

Tested against `chat.postMessage` on 2026-05-27 from this brain's Slack thread:

| Cell schema | Result |
|-------------|--------|
| `{ "type": "raw_number", "value": 47 }` | ❌ `invalid_blocks` |
| `{ "type": "raw_number", "text": "47" }` | ❌ `invalid_blocks` |
| `{ "type": "raw_number", "value": 47, "text": "47" }` | ✅ `ok` |

Docs ([data-table-block](https://docs.slack.dev/reference/block-kit/blocks/data-table-block)) list `text` as having "minimum length 1" on `raw_number` cells — i.e. required, not optional. My #132 PR missed the `text` field in the example.

## Changes

- Expanded *Cell types* description in `skills/slack/skill.md` to call out `value` + `text` as **both required** with an explicit note about the `invalid_blocks` rejection
- Fixed the `data_table` JSON example: `raw_number` cell now includes both fields

## Diff size

+9/-2. Tier 2, self-merge.

## Verify

Manually copy the example JSON into `send_message` blocks → should render as a 1-row data_table; sending the old (broken) shape → `invalid_blocks`.