### PR TITLE
fix(mcp/slack): pass through `blocks` + `attachments` in read_thread / read_channel

### DIFF
--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -506,6 +506,8 @@ async function handleTool(name, args) {
         text: m.text || '',
         ts: m.ts,
         is_bot: Boolean(m.bot_id),
+        ...(m.blocks?.length && { blocks: m.blocks }),
+        ...(m.attachments?.length && { attachments: m.attachments }),
         ...(m.files?.length && {
           files: m.files.map((f) => ({
             name: f.name,
@@ -557,6 +559,16 @@ async function handleTool(name, args) {
         is_bot: Boolean(m.bot_id),
         thread_ts: m.thread_ts,
         reply_count: m.reply_count,
+        ...(m.blocks?.length && { blocks: m.blocks }),
+        ...(m.attachments?.length && { attachments: m.attachments }),
+        ...(m.files?.length && {
+          files: m.files.map((f) => ({
+            name: f.name,
+            mimetype: f.mimetype,
+            url: f.url_private,
+            size: f.size,
+          })),
+        }),
       }))
       return { ok: true, messages }
     }

--- a/skills/slack/skill.md
+++ b/skills/slack/skill.md
@@ -35,13 +35,13 @@ Gracefully handles `no_reaction`.
 - `channel`: Override channel
 - `thread_ts`: Override thread
 
-Returns messages with `user`, `text`, `ts`, `is_bot`, and `files` (if any).
+Returns messages with `user`, `text`, `ts`, `is_bot`, `blocks` (raw Block Kit array if present), `attachments` (legacy attachments if present), `files` (metadata + `url`; fetch content via `download_file`).
 
 ### read_channel — Read channel history
 - `limit`: Max messages (default: 20)
 - `channel`: Override channel
 
-Returns messages with `user`, `text`, `ts`, `is_bot`, `thread_ts`, `reply_count`.
+Returns messages with `user`, `text`, `ts`, `is_bot`, `thread_ts`, `reply_count`, `blocks`, `attachments`, `files` (same shape as `read_thread`).
 
 ### upload_snippet — Upload code/text snippet
 - `title` (required): Snippet title


### PR DESCRIPTION
Implements fix for [teamvibeai/teamvibe.ai#140](https://github.com/teamvibeai/teamvibe.ai/issues/140) (initially mis-routed to `teamvibe.ai` — bug is in the base-brain MCP server, not the platform).

## Problem

`mcp__slack__read_thread` and `mcp__slack__read_channel` handlers in `mcp/slack.mjs` mapped only a fixed subset of fields from the upstream Slack `conversations.replies` / `conversations.history` response. The `blocks[]` (modern Block Kit) and `attachments[]` (legacy) arrays were silently dropped, so any message that put its content in blocks/attachments came back to the consuming agent as an empty `text` field.

Discovered during cross-test between VibeKeeper and JARVIS on 2026-05-28 (thread `C0AMYMD6LA0 / 1779889779.510669`) — agent A drafts a `markdown` block, agent B's `read_thread` sees only the short caption, draft body invisible.

## Change

`mcp/slack.mjs`:
- `read_thread` mapping: add conditional `blocks` + `attachments` pass-through (only when present, no allocation cost when absent)
- `read_channel` mapping: same, plus `files` mapping (was missing for `read_channel` — parity with `read_thread`)

`skills/slack/skill.md`:
- Update return-shape documentation for both `read_thread` and `read_channel` to mention `blocks`, `attachments`, `files`

No render layer, no transformation — raw pass-through from Slack API response. Matches the "raw `blocks`, no rendering" fix recommendation in #140.

## Diff

`mcp/slack.mjs` +12, `skills/slack/skill.md` +2/-2. Tier 2 (base-brain MCP + skill doc), self-merge per [MEM-4] criteria — small, well-justified, no breaking change (additive fields).

## Verify

After this lands + next session restart:
- `mcp__slack__read_thread` on cross-test thread `1779889779.510669` should expose Jarvis's markdown block content (TS `1779952718.111299`) and data_table block content (TS `1779952730.590359`) directly in `messages[].blocks`
- File uploads continue to work as before
- Existing consumers that look at `text` only see no behavior change

## Prior art

[anthropics/claude-code#51720](https://github.com/anthropics/claude-code/issues/51720) — same class of bug, Anthropic Slack MCP. Open since 2026-04-21. Their connector handles top-level blocks[] but drops legacy attachments[]; ours did neither. This PR surfaces both.

## Tier classification

Tier 2 base-brain (MCP server + skill doc). No code in `teamvibe.ai` platform. Self-merge.