### PR TITLE
Auto-improve: daily-log-weekly-coverage

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -45,8 +45,9 @@ If `memory/TODAY.md` doesn't exist, do NOT skip this step. Instead: create `memo
 **Step 0 checkpoint (required before proceeding):** Pause here and explicitly verify:
 - [ ] `memory/TODAY.md` is in your working `filesChanged` list
 - [ ] `memory/daily/YYYY-MM-DD.md` (today's date) is in `filesChanged` (unless TODAY.md did not exist prior to this run)
+- [ ] **Multi-date verification (required when TODAY.md had N > 1 date sections):** List every date section found in the original TODAY.md and confirm a separate daily file was written for each. Write this explicitly: `"Archived: 2026-05-15 → daily/2026-05-15.md ✓, 2026-05-16 → daily/2026-05-16.md ✓, 2026-05-17 → daily/2026-05-17.md ✓"`. If any section was missed (collapsed into another file), create the missing file now before proceeding. Skipping this produces a gap day that silently fails `daily-log-weekly-coverage` — the evaluator counts commits on that date as a session day with no log.
 
-If either entry is missing, add it now. Do NOT advance to Step 1 with these entries missing — the `today-md-archived` eval criterion checks `filesChanged` and will fail if TODAY.md is absent, even when the archival was performed correctly.
+If any entry is missing, add it now. Do NOT advance to Step 1 with these entries missing — the `today-md-archived` eval criterion checks `filesChanged` and will fail if TODAY.md is absent, even when the archival was performed correctly.
 
 ### 1. Scan Daily Logs
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** daily-log-weekly-coverage
**Eval date:** 2026-05-28
**Overall score:** 0.93

### Recent Eval History
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 81%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 29% <-- TARGET
- deletion-with-preservation-evidence: 86%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 69%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 94%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 77%
- today-md-archived: 99%
- update-relevant-tiers: 92%
- verifiable-recommendations: 80%

### What Changed
## Improvement Summary

**Target criterion:** daily-log-weekly-coverage
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Added a third verification item to the Step 0 checkpoint in the memory consolidation skill. The new item requires brains to explicitly list every date section found in the original TODAY.md and confirm a separate `memory/daily/YYYY-MM-DD.md` was created for each section — before advancing to Step 1.

Previously the checkpoint only verified:
1. `memory/TODAY.md` is in `filesChanged`
2. Today's daily file is in `filesChanged`

It did not verify that ALL date sections in a multi-section TODAY.md were separately archived. Pollers would read the ⚠️ warning about multiple date sections but still produce a single `daily/YYYY-MM-DD.md` file containing all sections, leaving all but the first date as uncovered session days.

### Root cause addressed

The `daily-log-weekly-coverage` criterion computes `days_with_daily_log / days_with_any_session ≥ 0.8`. When TODAY.md accumulates entries across multiple days (e.g., May 15–22) and all content is archived to `daily/2026-05-15.md` only, days May 16–22 each have commits (session days) but no corresponding daily log file. This produces coverage as low as 1/7 = 14% even when logging was happening.

Report insights confirmed this pattern: "Daily log 2026-05-15.md accumulated entries from multiple days (May 15-22) — violating one-log-per-day convention."

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation skill run during maintenance heartbeat

**Behavior change:** The Step 0 checkpoint now requires the consolidating brain to enumerate every date section from the original TODAY.md and confirm one daily file per section was created. For a TODAY.md with N date sections, the brain must produce N daily files — and must detect and fix any collapse before proceeding. This makes the multi-date archival requirement verifiable rather than advisory.

### Expected impact

Eliminates the primary driver of low weekly coverage scores: multi-day accumulation files. Brains that previously collapsed 7 days of content into a single daily file will now catch and fix the error at Step 0 before computing the compliance ratio in Step 10, raising `daily-log-weekly-coverage` pass rate from the current 40% toward ≥ 80%.

The change is backward compatible — brains with a single-date TODAY.md see no new requirement (the third checkpoint item is conditioned on N > 1 date sections).

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*