### PR TITLE
Auto-improve: daily-log-continuous-appends

### DIFF
--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -60,7 +60,7 @@ Rules:
 - **Minimum entry rule:** Every session that *performs a meaningful action* must create at least one log entry. This includes interactive sessions, maintenance that modifies files, heartbeats that execute tasks, triage runs, and health checks. Write the entry **before** any action that could fail or time out — if the session crashes, the log still has value.
   - **Exception — no-op heartbeats:** If a heartbeat session checks tasks and finds nothing to do (no pending tasks, no maintenance due, no actions taken), do **NOT** log anything. Silent exit is correct. Only log heartbeats that actually performed work (e.g., ran consolidation, completed a task, triggered a workflow).
   - **What to log when something happened:** `- 09:00 — heartbeat: ran consolidation, archived 3 daily logs` or `- 09:00 — WF triage ran, 2 failures (created WF-123)`. Keep it to what was *done*, not what was *skipped*.
-- **Append continuously, not at the end.** If the session ends abruptly (crash, context compaction, timeout), the log still has value because you wrote as you went.
+- **Append continuously, not at the end.** For sessions with multiple phases (maintenance, consolidation, multi-step tasks), write a log entry at the START of the session and again after each major phase completes — aim for 2+ entries with distinct timestamps. A single bullet added at session end fails the crash-resilience goal even if it is well-written.
 - **Don't batch-decide "what was important."** If you're unsure whether an entry is worth it, write it — removing noise is cheap during consolidation, reconstructing lost context is not.
 - **One line per entry is fine.** Brief is better than nothing.
 - Create the file if it doesn't exist. Start with a date header: `# YYYY-MM-DD`


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** daily-log-continuous-appends
**Eval date:** 2026-05-29
**Overall score:** 0.8433

### Recent Eval History
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 67% <-- TARGET
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 26%
- deletion-with-preservation-evidence: 86%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 75%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 91%
- semantic-naming-convention: 100%
- session-capture-has-context: 100%
- summary-md-regenerated: 74%
- today-md-archived: 97%
- update-relevant-tiers: 92%
- verifiable-recommendations: 91%

### What Changed
## Improvement Summary

**Target criterion:** daily-log-continuous-appends
**Files modified:** skills/memory/skill.md

### What changed

Replaced the vague "append continuously" guidance with explicit instruction requiring 2+ distinct timestamped entries for multi-phase sessions. The old text said only "if the session ends abruptly, the log still has value" — which doesn't prevent single-entry-at-end behavior. The new text says: write a log entry at the START of the session and again after each major phase, aiming for 2+ entries with distinct timestamps. It also explicitly states that a single bullet added at session end fails the crash-resilience goal.

The root cause was that the "minimum entry rule" (at least one log entry) combined with the vague "append continuously" text permitted single-entry behavior. The criterion requires 2+ distinct timestamped entries on days with multi-session activity.

Report insights confirmed the pattern: "Single-entry 'ranní otázka' pattern across entire 05-22 → 05-28 week — no day with 2+ user entries" and "Daily log coverage required backfill 2 of last 4 cycles — chore commits and quiet days are the recurring gap class."

### Skill Impact

**Skill:** memory/skill.md — Always-active memory management system governing how agents read, write, and organize memory.
**Behavior change:** The skill now explicitly instructs brains to write a log entry at session start AND after each major phase for multi-phase sessions (maintenance, consolidation, multi-step tasks), targeting 2+ entries with distinct timestamps rather than a single end-of-session summary.

### Expected impact

Brains will shift from single-entry-per-session logging to multi-entry continuous logging, directly addressing the 0% pass rate on `daily-log-continuous-appends`. Historical average was 0.67, so the underlying behavior is learnable — the missing signal was the explicit 2+ entries instruction.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*