### PR TITLE
Auto-improve: gap-impact-analysis

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -114,7 +114,7 @@ Produce both a markdown and JSON report in `reports/` as required by MAINTENANCE
 - `recommendations`: Specific actions for the next maintenance cycle. If any recommendation would benefit all agents (not just this channel), prefix it with `[base-brain]`. Examples:
   - "Split semantic/projects.md into per-project files — currently 120 lines"
   - "[base-brain] Add guidance on deduplicating recurring morning-reflection topics to prevent agents repeating the same question across days"
-- `selfAssessment`: Include at minimum `assess-memory-quality`, `actionable-recommendations`, `no-data-loss`.
+- `selfAssessment`: Use the actual reflection eval criterion IDs: `concrete-improvement-proposal`, `previous-recommendations-reviewed`, `gap-impact-analysis`, `verifiable-recommendations`, `deletion-with-preservation-evidence`. **Pre-submit gate for `gap-impact-analysis`:** scan every planned `observations` entry for gap-class language ('lacks', 'missing', 'thin', 'no entry for', 'gap in coverage'). Each such entry MUST name a specific incident + date as the consequence. Any gap entry without a named incident must be moved to `processImprovements` as `[proposal]` before writing the JSON. Set `gap-impact-analysis: true` only if at least one `observations` entry remains that pairs gap language with a specific named consequence.
 - `processImprovements`: Required for reflection reports. Include at least one entry per prefix type (`[self-critique]`, `[proposal]`, `[blocked]`). Reference prior recommendations that went unacted on. Examples:
   - `[self-critique] Reflection is running 45 days late — monthly schedule not enforced by any heartbeat check`
   - `[proposal] Add a 30-day check for last reflection date to HEARTBEAT.md so it triggers automatically`


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** gap-impact-analysis
**Eval date:** 2026-06-05
**Overall score:** 0.9017

### Recent Eval History
- concrete-improvement-proposal: 100%
- daily-log-continuous-appends: 69%
- daily-log-recent-retention: 100%
- daily-log-weekly-coverage: 45%
- deletion-with-preservation-evidence: 92%
- evidence-backed-decisions: 68%
- gap-impact-analysis: 41% <-- TARGET
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 79%
- semantic-naming-convention: 86%
- session-capture-has-context: 86%
- summary-md-regenerated: 86%
- today-md-archived: 90%
- update-relevant-tiers: 99%
- verifiable-recommendations: 81%

### What Changed
## Improvement Summary

**Target criterion:** gap-impact-analysis
**Files modified:** skills/memory/reflect/skill.md

### What changed

The `selfAssessment` line in the reflect skill's Output section referenced incorrect, non-existent criterion IDs (`assess-memory-quality`, `actionable-recommendations`, `no-data-loss`) instead of the actual reflection eval criteria. This meant pollers never explicitly self-checked `gap-impact-analysis` before submitting reports — there was no final forcing function to catch gap observations that lacked operational consequences.

The line was updated to:
1. List the actual reflection eval criterion IDs (`concrete-improvement-proposal`, `previous-recommendations-reviewed`, `gap-impact-analysis`, `verifiable-recommendations`, `deletion-with-preservation-evidence`)
2. Add an explicit pre-submit gate for `gap-impact-analysis`: scan every planned `observations` entry for gap-class language and verify each has a specific named consequence + date; move any consequence-less gap entries to `processImprovements` before writing the JSON

### Skill Impact

**Skill:** memory/reflect — Memory self-assessment skill for checking quality, resolving contradictions, and archiving stale entries.
**Behavior change:** The reflection skill now requires pollers to explicitly self-assess `gap-impact-analysis` (using the correct criterion ID) and perform a final scan of observations entries for gap-class language before writing the JSON report. This creates a forcing function at output time — not just during Step 3 — ensuring gap observations are backed by specific incidents with dates or are routed to `processImprovements` instead.

### Expected impact

The `gap-impact-analysis` pass rate should improve from 0% (latest) toward the historical average of ~41% and beyond. The root cause was a missing self-check at report-writing time; the fix adds an explicit gate that catches consequence-less gap observations before the report is committed.

### Report insights influence

No specific recommendations from `report-insights.md` directly addressed `gap-impact-analysis`. The fix is grounded in the criterion definition and the observed gap between the skill's Step 3 guidance (which was adequate) and the output stage (which lacked the enforcement step).

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*