### PR TITLE
docs: add thread_ts reply routing rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,20 @@ This applies equally to **other agents** in the thread (they won't see your repl
 
 When you want to bring a *new* participant into the conversation, tag them explicitly even if they haven't spoken yet (e.g., `<@U...>` for second opinion / handoff / escalation).
 
-> Tool-layer guardrail tracking: [teamvibeai/teamvibe.ai#108](https://github.com/teamvibeai/teamvibe.ai/issues/108) (deterministic warning hint from `send_message`); thread-continuity wake: [teamvibeai/teamvibe.ai#109](https://github.com/teamvibeai/teamvibe.ai/issues/109).
+### Reply thread routing — `thread_ts` defaults
+
+Your session's current thread is encoded in the inbox path: `.inbox/SESSION:CHANNEL_ID:THREAD_TS/`. The `send_message` tool defaults to this thread when `thread_ts` is omitted.
+
+**Rule: omit `thread_ts` by default.** Set it explicitly only when one of these legitimate cases applies:
+
+1. **Cross-thread handoff** — the user's current message explicitly references a different thread (TS string, archive URL, or thread permalink).
+2. **Scheduled message with explicit target** — the scheduler triggered you with a target thread that is not your wake source.
+3. **Agent-to-agent reference back to a source thread** — replying to a wake from another thread.
+4. **`thread_ts: null`** — explicit top-level channel post (broadcast pattern).
+
+**Memory recall of "the thread we discussed this in before" is NOT sufficient justification** to override the default. If you find yourself reaching for a thread TS from prior session context, stop and use the inbox-encoded current thread — that's where the user actually is right now. Setting `thread_ts` explicitly without one of the four cases above is a red flag; justify the override in the same turn or omit it.
+
+> Tool-layer guardrail history: [teamvibeai/teamvibe.ai#108](https://github.com/teamvibeai/teamvibe.ai/issues/108) (CLOSED 2026-05-28, `missing_recipient_tag` warning shipped via poller-brain#136); thread-continuity wake: [teamvibeai/teamvibe.ai#109](https://github.com/teamvibeai/teamvibe.ai/issues/109); `thread_ts` override guardrail: [teamvibeai/teamvibe.ai#184](https://github.com/teamvibeai/teamvibe.ai/issues/184) (in design).
 
 ## Persistent Storage
 


### PR DESCRIPTION
## Summary

Adds an explicit `thread_ts` reply routing rule to base-brain `CLAUDE.md` (Slack section), complementing the in-design tool-layer warning in [teamvibeai/teamvibe.ai#184](https://github.com/teamvibeai/teamvibe.ai/issues/184).

The new subsection `### Reply thread routing — thread_ts defaults`:
- States the default rule: **omit `thread_ts`** (let the tool default to inbox-encoded current thread)
- Enumerates the four legitimate override cases (cross-thread handoff, scheduled target, agent-to-agent reference, `thread_ts: null` broadcast)
- Explicitly calls out **memory-recall of a prior thread is NOT sufficient justification** — that's the exact failure mode from the 2026-06-05 J.A.R.V.I.S incident that triggered #184

Also updates the tracking blockquote:
- #108 marked CLOSED (`missing_recipient_tag` shipped 2026-05-28 via poller-brain#136)
- #184 added as in-design override guardrail

## Why this is its own change (not bundled with #184)

#184 is a Tier 2 platform change (`mcp/slack.mjs` + `claude-spawner.ts`, blast radius cross-fleet) — needs DevGuru ack before code PR.

This CLAUDE.md update is Tier 1 (text only, no code), self-merge OK after review. Decoupling means agent-side behavior contract ships today, independent of the tool-side ship timeline.

## Background

Incident 2026-06-05: 4 consecutive Slack replies landed in the wrong thread because the agent hardcoded `thread_ts` to a remembered briefing TS instead of using the session's inbox-encoded run-thread default.

Discussion in #ai-teamvibe (thread `1780660918.704839`) between J.A.R.V.I.S and VibeKeeper produced the two-component design tracked in #184 (tool-layer) and this PR (prompt-layer rule).

## Test plan

- [x] Manually verify CLAUDE.md renders correctly on GitHub (no broken markdown)
- [x] Confirm tracking blockquote links resolve: #108, #109, #184
- [x] Spot-check that the rule wording matches #184 Exception list (4 cases)

Refs: teamvibeai/teamvibe.ai#184
