### PR TITLE
Auto-improve: verifiable-recommendations

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -111,9 +111,10 @@ Produce both a markdown and JSON report in `reports/` as required by MAINTENANCE
   - "No procedural documentation exists for the weekly-standup workflow, which led to 4 inconsistent invocations across the last 5 standup runs" — gap + observed consequence
   - "episodic/ covers the last 3 months well; the last 2 questions about pre-Q1 incidents required Slack history dives because no episodic entries cover that period" — gap + observed consequence
   - Vague impact language like "this may affect quality" does NOT qualify — the consequence must be specific and already observed.
-- `recommendations`: Specific actions for the next maintenance cycle. If any recommendation would benefit all agents (not just this channel), prefix it with `[base-brain]`. Examples:
-  - "Split semantic/projects.md into per-project files — currently 120 lines"
-  - "[base-brain] Add guidance on deduplicating recurring morning-reflection topics to prevent agents repeating the same question across days"
+- `recommendations`: Specific actions for the next maintenance cycle. If any recommendation would benefit all agents (not just this channel), prefix it with `[base-brain]`. **At least one recommendation MUST follow this three-part format: (1) concrete change to make, (2) the current problem it addresses, and (3) a verifiable success condition.** Use inline labels: `current problem:` and `success criterion:`. Single-sentence observations ("split X", "monitor Y") without a stated problem and success condition do NOT satisfy this requirement.
+  - Bad: "Split semantic/projects.md into per-project files."
+  - Good: "Split semantic/projects.md into per-project files; current problem: file is 120 lines and slow to scan; success criterion: next consolidation reports two sub-files each under 70 lines."
+  - "[base-brain] Add guidance on deduplicating recurring morning-reflection topics; current problem: agents repeat the same question across days without resolving it; success criterion: next reflection names zero repeated-unresolved topics."
 - `selfAssessment`: Include at minimum `assess-memory-quality`, `actionable-recommendations`, `no-data-loss`.
 - `processImprovements`: Required for reflection reports. Include at least one entry per prefix type (`[self-critique]`, `[proposal]`, `[blocked]`). Reference prior recommendations that went unacted on. Examples:
   - `[self-critique] Reflection is running 45 days late — monthly schedule not enforced by any heartbeat check`


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** verifiable-recommendations
**Eval date:** 2026-06-10
**Overall score:** 0.9099

### Recent Eval History
- concrete-improvement-proposal: 100%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 84%
- gap-impact-analysis: 38%
- previous-recommendations-reviewed: 99%
- process-self-critique: 100%
- reduce-log-count: 88%
- semantic-naming-convention: 86%
- summary-md-regenerated: 84%
- today-md-archived: 84%
- update-relevant-tiers: 77%
- verifiable-recommendations: 67% <-- TARGET

### What Changed
## Improvement Summary

**Target criterion:** verifiable-recommendations
**Files modified:** skills/memory/reflect/skill.md

### What changed

Updated the `recommendations` field guidance in the reflection skill to explicitly require the three-part format mandated by the `verifiable-recommendations` criterion. The previous guidance only gave two minimal examples that lacked success criteria — "Split semantic/projects.md into per-project files — currently 120 lines" contains no stated problem and no verifiable success condition.

The new guidance:
- States that **at least one recommendation MUST follow the three-part format**: (1) concrete change, (2) current problem it addresses, (3) verifiable success condition
- Labels the required inline components (`current problem:`, `success criterion:`)
- Replaces the passing bad example with a labeled bad/good pair showing the difference
- Updates the `[base-brain]` example to also follow the three-part format

### Skill Impact

**Skill:** memory/reflect — Memory self-assessment skill run during maintenance heartbeat.

**Behavior change:** When producing the JSON `recommendations` array, the agent will now explicitly write at least one recommendation with all three components. Previously the skill provided no guidance on the format, and agents frequently produced action-only recommendations like "Split X" or "Monitor Y" with no problem statement or success criterion — which fails `verifiable-recommendations`. The updated guidance with a bad/good example makes the required format concrete and hard to miss.

### Expected impact

Reflection reports should now consistently include at least one three-part recommendation, improving the `verifiable-recommendations` pass rate from the current 66.67% toward 100%.

### Report insights influence

The good examples in the updated guidance were modeled after high-quality recommendations observed in the report-insights (e.g., "Add a post-promotion grep-verify gate to consolidation step 1b; current problem: MEM-1/MEM-2 went unwritten for 35 days undetected; verifiable when a future consolidation report's MEM Audit shows '0 missing ACTIVE keys verified by grep'") — confirming this pattern is achievable by the brains producing these reports.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*