### PR TITLE
fix(memory): mem-write — drop 57-char truncation, escape pipes + newlines

### DIFF
--- a/skills/memory/scripts/mem-write.ts
+++ b/skills/memory/scripts/mem-write.ts
@@ -81,8 +81,8 @@ function main(): void {
   const key = getNextKey();
   const today = getToday();
 
-  // Short description for registry (first 60 chars)
-  const desc = content.length > 60 ? content.slice(0, 57) + "..." : content;
+  // Escape pipes (markdown table separator) and collapse newlines; keep full content per #150
+  const desc = content.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
 
   // Append to TODAY.md
   fs.appendFileSync(TODAY_PATH, `- [MEM-${key}] ${content}\n`);


### PR DESCRIPTION
## Summary
- Removes silent 57-char truncation in `skills/memory/scripts/mem-write.ts` when writing `description` into `memory/MEM_REGISTRY.md`.
- Escapes the only two chars that actually break a markdown-table row: `|` → `\|`, and `\r?\n` → space.
- Keeps full content in the registry.

## Why
`MEM_REGISTRY.md` is a markdown table. Row breakage is caused by `|` (column separator) or newlines inside a cell — not by length. The 57-char cap was silent data loss with zero benefit. Issue [#150](https://github.com/teamvibeai/poller-brain/issues/150) (TiketoDev-reported, recurred 4× consolidation cycles).

Newline escape added per DevGuru review — `process.argv` can (rarely) contain a literal `\n` via shell heredoc or quoted multiline arg; without the replace a single newline would split the row in two.

## Diff
```ts
-  // Short description for registry (first 60 chars)
-  const desc = content.length > 60 ? content.slice(0, 57) + "..." : content;
+  // Escape pipes (markdown table separator) and collapse newlines; keep full content per #150
+  const desc = content.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
```

## Test plan
- [x] Smoke `npx tsx mem-write.ts "long description with | pipe and >60 chars …"` → registry row contains full content, pipe escaped as `\|`.
- [x] Smoke with embedded literal newline in arg → row stays single-line, content joined with space.
- [x] TODAY.md append unchanged (already full content, not a table).

## Tier
- Tier 2 ([MEM-35] — `skills/memory/*`) — DevGuru ack'd in Slack 2026-06-11 05:37 UTC.

Closes #150