### PR TITLE
Auto-improve: previous-recommendations-reviewed

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -15,7 +15,20 @@ Periodic self-assessment of memory quality. Run monthly.
 
 Before starting, find the most recent reflection report in `memory/episodic/reflection-*.md` or `reports/*-memory-reflection.json`. Check which recommendations from that report were acted on since then.
 
-**Action:** Note in this reflection which prior recommendations were implemented, which were ignored, and why. This feeds the `processImprovements` field.
+**Action (required — this step is mandatory, not optional):** For each recommendation from the prior reflection report, write one entry in `processImprovements` using this exact format:
+
+```
+[prev-rec] From YYYY-MM-DD reflection: '<recommendation text>' → STATUS: <implemented|partially-addressed|pending> — <one-sentence reason>
+```
+
+At minimum, document at least one prior recommendation this way. If no prior reflection report exists, add: `[prev-rec] No prior reflection report found — this is the first reflection run.`
+
+Example:
+```
+[prev-rec] From 2026-05-15 reflection: 'Split semantic/projects.md into per-project files' → STATUS: pending — no new projects landed this cycle so split was deferred.
+```
+
+This is the evidence the eval pipeline uses to verify `previous-recommendations-reviewed`. A generic self-critique entry does NOT satisfy this requirement — the entry must name a specific prior recommendation and its disposition.
 
 ### 1. Staleness Check
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** previous-recommendations-reviewed
**Eval date:** 2026-06-13
**Overall score:** 0.8169

### Recent Eval History
- concrete-improvement-proposal: 100%
- deletion-with-preservation-evidence: 86%
- evidence-backed-decisions: 71%
- gap-impact-analysis: 52%
- previous-recommendations-reviewed: 88% <-- TARGET
- process-self-critique: 100%
- reduce-log-count: 74%
- semantic-naming-convention: 57%
- summary-md-regenerated: 81%
- today-md-archived: 68%
- update-relevant-tiers: 82%
- verifiable-recommendations: 77%

### What Changed
## Improvement Summary

**Target criterion:** previous-recommendations-reviewed
**Files modified:** skills/memory/reflect/skill.md

### What changed

Step 0 of the reflection skill ("Previous Recommendations Review") was expanded from a vague instruction ("Note in this reflection which prior recommendations were implemented, which were ignored, and why. This feeds the `processImprovements` field.") to a mandatory, format-prescribed step.

The change adds:
1. An explicit statement that this step is **mandatory**, not optional
2. A required `[prev-rec]` format for `processImprovements` entries that names the specific prior recommendation and its disposition (`implemented`, `partially-addressed`, or `pending`)
3. A concrete example entry
4. A fallback for when no prior reflection report exists (`[prev-rec] No prior reflection report found...`)
5. An explicit note that generic self-critique does NOT satisfy this requirement

### Expected impact

The criterion pass condition is: "Report explicitly references at least one recommendation from a prior maintenance cycle and states whether it was implemented, partially addressed, or remains pending."

Previously, pollers would mention prior work in vague processImprovements entries or skip Step 0 entirely, producing reports the evaluator could not reliably match. The new `[prev-rec]` format gives the evaluator a clear signal to scan for, and the mandatory framing prevents pollers from skipping this step when they have "nothing notable" to report.

Expected improvement: from 23.53% to close to the historical average of ~88%, since every reflection run will now include at least one `[prev-rec]` entry.

### Skill Impact

**Skill:** memory/reflect — Memory self-assessment skill run during maintenance to check memory quality, resolve contradictions, and archive stale entries.

**Behavior change:** The reflection skill will now always produce at least one `[prev-rec]`-prefixed `processImprovements` entry documenting the status of a prior recommendation, using a prescribed format the evaluator can reliably detect. This does not change any other aspect of the reflection process.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*