### PR TITLE
fix(memory): anchor mem-write scan to canonical TODAY.md rows

### DIFF
--- a/skills/memory/scripts/mem-write.ts
+++ b/skills/memory/scripts/mem-write.ts
@@ -26,10 +26,10 @@ const REGISTRY_HEADER = `# MEM Registry
 |-----|--------|---------|-----------|-------------|
 `;
 
-function scanMaxKey(filePath: string): number {
+function scanMaxKey(filePath: string, pattern: RegExp): number {
   if (!fs.existsSync(filePath)) return 0;
   const content = fs.readFileSync(filePath, "utf-8");
-  const matches = content.matchAll(/MEM-(\d+)/g);
+  const matches = content.matchAll(pattern);
   let max = 0;
   for (const m of matches) {
     const n = parseInt(m[1], 10);
@@ -39,8 +39,10 @@ function scanMaxKey(filePath: string): number {
 }
 
 function getNextKey(): number {
-  const fromRegistry = scanMaxKey(REGISTRY_PATH);
-  const fromToday = scanMaxKey(TODAY_PATH);
+  // REGISTRY rows are pipe-tabled (`| MEM-N | ACTIVE | ...`) and have no prose drift risk — full scan is safe and acts as defense-in-depth.
+  const fromRegistry = scanMaxKey(REGISTRY_PATH, /MEM-(\d+)/g);
+  // TODAY.md mixes canonical write rows with prose mentions (e.g. review summaries). Restrict to anchored canonical rows: `- [MEM-N] ...`. Permit whitespace or colon after `]` for forward-compat with format drift.
+  const fromToday = scanMaxKey(TODAY_PATH, /^- \[MEM-(\d+)\][\s:\]]/gm);
   return Math.max(fromRegistry, fromToday) + 1;
 }
 


### PR DESCRIPTION
## Summary

- Closes #181 — `scanMaxKey` over-matched `MEM-N` tokens in TODAY.md prose, causing a permanent ~70-entry gap (MEM-7 → MEM-79) on 2026-06-08.
- Anchor TODAY.md scan to canonical write rows: `/^- \[MEM-(\d+)\][\s:\]]/gm`. The `[\s:\]]` after `]` tolerates `space` vs `:` format drift.
- REGISTRY scan keeps the original full `/MEM-(\d+)/g` pattern as defense-in-depth — its rows are pipe-tabled, no prose drift risk.

## Why this regex

- Sanity-checked canonical rows across brain mirror — all entries use `- [MEM-N] ` form, no `:` drift in the wild, but the lenient bracket class costs nothing and prevents silent zero-match on future drift.
- 5-line smoke fixture (prose mention `MEM-78` + canonical `- [MEM-3]` row) confirms the new regex returns 3, old returns 78.

## Follow-up

- Smoke harness for `scripts/memory/*` will land as a separate issue (out of scope for this hygiene fix).

## Test plan
- [x] Manual fixture: prose `MEM-78` + canonical `- [MEM-3]` row → returns 3
- [x] Sanity-checked canonical row format across brain mirror
- [ ] Self-test in next reflection cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)