### PR TITLE
docs(claude.md): add Secrets section + bundle secret-receiver skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,19 +163,30 @@ When a user wants to add or rotate a secret, route them to the platform UI, whic
 
 A `secret` skill is on the roadmap — it'll open a Slack-anchored modal via HTTPS tunnel so the user can submit a value without leaving Slack, and without the plaintext entering the conversation. Until that skill ships, the platform UI is the canonical entry point for user-driven secret creation.
 
-Direct REST `PUT /secrets` calls with the poller token *do* work (machine-entity workspace-boundary auth, not Owner-role gated), but reserve them for:
+### REST `PUT/DELETE /secrets` is poller-scope only
 
-- Migration scripts (importing from a legacy `.env`)
-- Automated rotation (regenerate-and-store flows)
-- One-off operational fixes where no user value entry is involved
+The Poller API write endpoints (`PUT /secrets`, `DELETE /secrets`) accept your token for **poller-scope writes only**. Workspace-scope writes via REST are denied with HTTP 403; channel-scope writes additionally require that the target `channelId` reference a non-deleted Channel row in the requested workspace.
 
-Never for a value the user is typing at you in chat.
+| Scope | REST `PUT`/`DELETE` via poller token | Where to write instead |
+|---|---|---|
+| `poller` | ✅ allowed (self-rotation use cases) | — |
+| `workspace` | ❌ HTTP 403 ([#212](https://github.com/teamvibeai/teamvibe.ai/issues/212)) | GraphQL `Mutation.putSecret` / `deleteSecret` (Owner-only via `withWorkspaceAuth`) — i.e. the platform UI |
+| `channel` | ✅ allowed *if* the Channel row exists; HTTP 403 otherwise ([#213](https://github.com/teamvibeai/teamvibe.ai/issues/213)) | Same Owner-only GraphQL path or REST if you have the existing channelId |
+
+This means REST writes are appropriate for:
+
+- **Poller-scope self-rotation** — an agent regenerating its own credentials and persisting them at its own `pollerId`
+- **Migration scripts** importing legacy `.env` keys to poller scope
+- **Automated rotation** at poller scope where no user value entry is involved
+
+Use the platform UI (Owner-role human path) for workspace or new-channel secret entry.
 
 ### Trust model — quick reference
 
 - Values: SSM SecureString at `/teamvibe/secret/<scope>/<scopeId>[/<channelId>]/<name>` (KMS-encrypted at rest)
 - Metadata (name, expiresAt, audit fields): DDB `Secret` entity
-- Backend authz (`authorizeScope`): poller-token → workspace boundary via `PollerAssignment` or `ownerWorkspaceId` match
+- Backend authz (`authorizeScope`): poller-token → workspace boundary via `PollerAssignment` or `ownerWorkspaceId` match, plus channel-existence gate for channel-scope calls ([#213](https://github.com/teamvibeai/teamvibe.ai/issues/213))
+- REST write asymmetry: workspace-scope writes denied at the REST layer ([#212](https://github.com/teamvibeai/teamvibe.ai/issues/212)); only the GraphQL Owner-only path can mutate workspace-scope secrets
 - Frontend authz (`withWorkspaceAuth`): Owner-role-only on the GraphQL `putSecret`/`deleteSecret` mutations — the UI gate
 - Write-only model: a stored value is never returned by `/secrets/list` or the UI after the initial save. The only path that surfaces values is `/secrets/spawn` (poller-token only, single call per session start)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ When a user wants to add or rotate a secret, route them to the platform UI, whic
 
 ### Safely receiving a secret value from the user
 
-If you need to capture a plaintext secret on the agent host (e.g. to land it in a poller-scope store via REST, to bridge into the host's macOS Keychain for use by host tooling, or as a staging step before the user pastes it into the platform UI), **do not ask the user to type the value into the Slack thread**. Use the `secret-receiver` skill bundled at `skills/secret-receiver/` — it ships with this base-brain so every poller has it without depending on optional submodules.
+If you need to capture a plaintext secret on the agent host (e.g. to land it in a poller-scope store via REST, or as a staging step before the user pastes it into the platform UI), **do not ask the user to type the value into the Slack thread**. Use the `secret-receiver` skill bundled at `$CLAUDE_CONFIG_DIR/skills/secret-receiver/` — it ships with this base-brain so every poller has it without depending on optional submodules, and it's OS-agnostic (no macOS Keychain, no `security` CLI).
 
 The skill flow:
 
@@ -173,20 +173,19 @@ The skill flow:
      --service "gitlab.com" --title "GitLab Token" \
      --description "Paste your Personal Access Token"
    ```
+   Server prints `SERVER_READY on port 3456` and `OUT_FILE <path>` to stdout.
 2. Agent runs `npx --yes localtunnel --port 3456` to mint a temporary public HTTPS URL.
 3. Agent posts the URL to the user via Slack.
 4. User opens the URL in a browser, pastes the value into the form, submits.
-5. The server saves the value to macOS Keychain (`security add-generic-password -s "<service>" -U -w "<value>"`), responds with a confirmation page, and shuts itself down after the single submission.
-6. Agent reads the value back when needed: `security find-generic-password -s "<service>" -w`.
+5. Server writes the value to the announced `OUT_FILE` path with mode `0600`, prints `TOKEN_RECEIVED <path>` on stdout, returns the success page, and shuts itself down ~2s later.
+6. Agent picks the value up by piping the file *directly* into the consumer (e.g. `curl --data-binary @<path>` or, for JSON bodies, a one-line `node -e '...JSON.stringify({scope, scopeId, name, value: fs.readFileSync(argv[1])})...'` pipe). Then `rm <path>`.
 
-The plaintext value never traverses Slack — it goes user-browser → encrypted tunnel → agent host → Keychain. The form auto-closes after one submission so the URL is single-use.
+The plaintext value never traverses Slack and never appears on the server's stdout — only the file path does. As long as the agent pipes the file straight into the next consumer (never `value=$(cat …)` or any other shell-variable detour) the plaintext also stays out of LLM context.
 
 **After capture, where the value lands depends on the target scope:**
 
-- *Poller scope* (e.g. an agent rotating its own GitLab PAT): read from Keychain → `PUT /secrets scope=poller` with your token. This is the only REST write the platform accepts from a poller token post-#212.
-- *Workspace / channel scope*: REST `PUT` is denied (workspace) or limited (channel-existence gated) for the poller path. Direct the user to the platform UI (`/settings/secrets`, `/channels/<channelId>`, etc.) and tell them they can paste from Keychain — `security find-generic-password -s "<service>" -w | pbcopy` is the typical helper. The platform UI then mutates via the Owner-only GraphQL path.
-
-The `secret-receiver` skill targets macOS hosts (uses the `security` CLI). Non-macOS pollers would need a Keychain replacement — track in the skill's README when that surfaces.
+- *Poller scope* (e.g. an agent rotating its own GitLab PAT): pipe the file into `PUT /secrets scope=poller` with your token. This is the only REST write the platform accepts from a poller token post-#212.
+- *Workspace / channel scope*: REST `PUT` is denied (workspace) or limited (channel-existence gated) for the poller path. Direct the user to the platform UI (`/settings/secrets`, `/channels/<channelId>`, etc.). If the user wants the captured value handed back to them for the UI paste, surface the file path in a follow-up Slack message and tell them to read it once (`cat <path>`) and then delete it. Better still: skip the capture-then-paste round trip entirely for these scopes and route them straight to the UI.
 
 A first-party `secret` skill that opens a Slack-anchored modal (no browser hop) is on the roadmap. Until it lands, `secret-receiver` is the path.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,34 @@ When a user wants to add or rotate a secret, route them to the platform UI, whic
 - Channel-scope: `/channels/<channelId>` (Secrets section)
 - Poller-scope: `/pollers/<pollerId>` (Secrets section)
 
-A `secret` skill is on the roadmap — it'll open a Slack-anchored modal via HTTPS tunnel so the user can submit a value without leaving Slack, and without the plaintext entering the conversation. Until that skill ships, the platform UI is the canonical entry point for user-driven secret creation.
+### Safely receiving a secret value from the user
+
+If you need to capture a plaintext secret on the agent host (e.g. to land it in a poller-scope store via REST, to bridge into the host's macOS Keychain for use by host tooling, or as a staging step before the user pastes it into the platform UI), **do not ask the user to type the value into the Slack thread**. Use the `secret-receiver` skill from the `skills/shared/` submodule (`knedlopark/shared-claude-skills`).
+
+The skill flow:
+
+1. Agent starts a local Node.js HTTP server with an HTML form:
+   ```bash
+   node skills/shared/secret-receiver/server.mjs \
+     --service "gitlab.com" --title "GitLab Token" \
+     --description "Paste your Personal Access Token"
+   ```
+2. Agent runs `npx --yes localtunnel --port 3456` to mint a temporary public HTTPS URL.
+3. Agent posts the URL to the user via Slack.
+4. User opens the URL in a browser, pastes the value into the form, submits.
+5. The server saves the value to macOS Keychain (`security add-generic-password -s "<service>" -U -w "<value>"`), responds with a confirmation page, and shuts itself down after the single submission.
+6. Agent reads the value back when needed: `security find-generic-password -s "<service>" -w`.
+
+The plaintext value never traverses Slack — it goes user-browser → encrypted tunnel → agent host → Keychain. The form auto-closes after one submission so the URL is single-use.
+
+**After capture, where the value lands depends on the target scope:**
+
+- *Poller scope* (e.g. an agent rotating its own GitLab PAT): read from Keychain → `PUT /secrets scope=poller` with your token. This is the only REST write the platform accepts from a poller token post-#212.
+- *Workspace / channel scope*: REST `PUT` is denied (workspace) or limited (channel-existence gated) for the poller path. Direct the user to the platform UI (`/settings/secrets`, `/channels/<channelId>`, etc.) and tell them they can paste from Keychain — `security find-generic-password -s "<service>" -w | pbcopy` is the typical helper. The platform UI then mutates via the Owner-only GraphQL path.
+
+The `secret-receiver` skill targets macOS hosts (uses the `security` CLI). Non-macOS pollers would need a Keychain replacement — track in the skill's README when that surfaces.
+
+A first-party `secret` skill that opens a Slack-anchored modal (no browser hop) is on the roadmap. Until it lands, `secret-receiver` is the path.
 
 ### REST `PUT/DELETE /secrets` is poller-scope only
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,13 +163,13 @@ When a user wants to add or rotate a secret, route them to the platform UI, whic
 
 ### Safely receiving a secret value from the user
 
-If you need to capture a plaintext secret on the agent host (e.g. to land it in a poller-scope store via REST, to bridge into the host's macOS Keychain for use by host tooling, or as a staging step before the user pastes it into the platform UI), **do not ask the user to type the value into the Slack thread**. Use the `secret-receiver` skill from the `skills/shared/` submodule (`knedlopark/shared-claude-skills`).
+If you need to capture a plaintext secret on the agent host (e.g. to land it in a poller-scope store via REST, to bridge into the host's macOS Keychain for use by host tooling, or as a staging step before the user pastes it into the platform UI), **do not ask the user to type the value into the Slack thread**. Use the `secret-receiver` skill bundled at `skills/secret-receiver/` — it ships with this base-brain so every poller has it without depending on optional submodules.
 
 The skill flow:
 
 1. Agent starts a local Node.js HTTP server with an HTML form:
    ```bash
-   node skills/shared/secret-receiver/server.mjs \
+   node $CLAUDE_CONFIG_DIR/skills/secret-receiver/server.mjs \
      --service "gitlab.com" --title "GitLab Token" \
      --description "Paste your Personal Access Token"
    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,94 +127,9 @@ If `$PERSISTENT_STORAGE_PATH` is set, you can use it for files that should persi
 
 ## Secrets
 
-The platform provides a per-spawn secrets envelope auto-injected into your `process.env` before each session starts. Three scopes merge into one env map with **channel > workspace > poller** precedence — a name at a higher scope overrides the same name at lower ones.
+Platform-managed secrets are auto-injected into your `process.env` at session start, merged from poller / workspace / channel scopes (channel > workspace > poller precedence). Read them as normal env vars (`$YOUR_API_KEY`). Stored values are **write-only** after save — no list endpoint returns plaintext; only the spawn-time injection does.
 
-### Reading secrets
-
-Use `process.env` directly — no extra calls needed in the normal path:
-
-```bash
-$YOUR_API_KEY
-```
-
-To discover what's *registered* at the platform (names + scopes only, never values), use the Poller API list endpoints with your existing token:
-
-```bash
-# Replace SCOPE with: poller | workspace | channel
-curl -H "Authorization: Bearer $TEAMVIBE_POLLER_TOKEN" \
-  "$TEAMVIBE_API_URL/secrets/list?scope=workspace&scopeId=$TEAMVIBE_WORKSPACE_ID"
-
-# channel scope additionally requires channelId:
-curl -H "Authorization: Bearer $TEAMVIBE_POLLER_TOKEN" \
-  "$TEAMVIBE_API_URL/secrets/list?scope=channel&scopeId=$TEAMVIBE_WORKSPACE_ID&channelId=$TEAMVIBE_CHANNEL_ID"
-```
-
-Note: `process.env` may also carry values from the **poller's local `.env` file** (host-level config loaded at poller startup). If a name appears in env but not in any `/secrets/list` response, it's coming from that local file — not from the platform — and isn't manageable via the API.
-
-### Adding / updating secrets
-
-**Do not POST plaintext values through Slack chat or a curl-with-poller-token from a user-facing session.** Plaintext belongs nowhere in the conversation transcript.
-
-When a user wants to add or rotate a secret, route them to the platform UI, which masks the value input, enforces Owner-only RBAC, and clears the form on submit:
-
-- Workspace-scope: `/settings/secrets`
-- Channel-scope: `/channels/<channelId>` (Secrets section)
-- Poller-scope: `/pollers/<pollerId>` (Secrets section)
-
-### Safely receiving a secret value from the user
-
-If you need to capture a plaintext secret on the agent host (e.g. to land it in a poller-scope store via REST, or as a staging step before the user pastes it into the platform UI), **do not ask the user to type the value into the Slack thread**. Use the `secret-receiver` skill bundled at `$CLAUDE_CONFIG_DIR/skills/secret-receiver/` — it ships with this base-brain so every poller has it without depending on optional submodules, and it's OS-agnostic (no macOS Keychain, no `security` CLI).
-
-The skill flow:
-
-1. Agent starts a local Node.js HTTP server with an HTML form:
-   ```bash
-   node $CLAUDE_CONFIG_DIR/skills/secret-receiver/server.mjs \
-     --service "gitlab.com" --title "GitLab Token" \
-     --description "Paste your Personal Access Token"
-   ```
-   Server prints `SERVER_READY on port 3456` and `OUT_FILE <path>` to stdout.
-2. Agent runs `npx --yes localtunnel --port 3456` to mint a temporary public HTTPS URL.
-3. Agent posts the URL to the user via Slack.
-4. User opens the URL in a browser, pastes the value into the form, submits.
-5. Server writes the value to the announced `OUT_FILE` path with mode `0600`, prints `TOKEN_RECEIVED <path>` on stdout, returns the success page, and shuts itself down ~2s later.
-6. Agent picks the value up by piping the file *directly* into the consumer (e.g. `curl --data-binary @<path>` or, for JSON bodies, a one-line `node -e '...JSON.stringify({scope, scopeId, name, value: fs.readFileSync(argv[1])})...'` pipe). Then `rm <path>`.
-
-The plaintext value never traverses Slack and never appears on the server's stdout — only the file path does. As long as the agent pipes the file straight into the next consumer (never `value=$(cat …)` or any other shell-variable detour) the plaintext also stays out of LLM context.
-
-**After capture, where the value lands depends on the target scope:**
-
-- *Poller scope* (e.g. an agent rotating its own GitLab PAT): pipe the file into `PUT /secrets scope=poller` with your token. This is the only REST write the platform accepts from a poller token post-#212.
-- *Workspace / channel scope*: REST `PUT` is denied (workspace) or limited (channel-existence gated) for the poller path. Direct the user to the platform UI (`/settings/secrets`, `/channels/<channelId>`, etc.). If the user wants the captured value handed back to them for the UI paste, surface the file path in a follow-up Slack message and tell them to read it once (`cat <path>`) and then delete it. Better still: skip the capture-then-paste round trip entirely for these scopes and route them straight to the UI.
-
-A first-party `secret` skill that opens a Slack-anchored modal (no browser hop) is on the roadmap. Until it lands, `secret-receiver` is the path.
-
-### REST `PUT/DELETE /secrets` is poller-scope only
-
-The Poller API write endpoints (`PUT /secrets`, `DELETE /secrets`) accept your token for **poller-scope writes only**. Workspace-scope writes via REST are denied with HTTP 403; channel-scope writes additionally require that the target `channelId` reference a non-deleted Channel row in the requested workspace.
-
-| Scope | REST `PUT`/`DELETE` via poller token | Where to write instead |
-|---|---|---|
-| `poller` | ✅ allowed (self-rotation use cases) | — |
-| `workspace` | ❌ HTTP 403 ([#212](https://github.com/teamvibeai/teamvibe.ai/issues/212)) | GraphQL `Mutation.putSecret` / `deleteSecret` (Owner-only via `withWorkspaceAuth`) — i.e. the platform UI |
-| `channel` | ✅ allowed *if* the Channel row exists; HTTP 403 otherwise ([#213](https://github.com/teamvibeai/teamvibe.ai/issues/213)) | Same Owner-only GraphQL path or REST if you have the existing channelId |
-
-This means REST writes are appropriate for:
-
-- **Poller-scope self-rotation** — an agent regenerating its own credentials and persisting them at its own `pollerId`
-- **Migration scripts** importing legacy `.env` keys to poller scope
-- **Automated rotation** at poller scope where no user value entry is involved
-
-Use the platform UI (Owner-role human path) for workspace or new-channel secret entry.
-
-### Trust model — quick reference
-
-- Values: SSM SecureString at `/teamvibe/secret/<scope>/<scopeId>[/<channelId>]/<name>` (KMS-encrypted at rest)
-- Metadata (name, expiresAt, audit fields): DDB `Secret` entity
-- Backend authz (`authorizeScope`): poller-token → workspace boundary via `PollerAssignment` or `ownerWorkspaceId` match, plus channel-existence gate for channel-scope calls ([#213](https://github.com/teamvibeai/teamvibe.ai/issues/213))
-- REST write asymmetry: workspace-scope writes denied at the REST layer ([#212](https://github.com/teamvibeai/teamvibe.ai/issues/212)); only the GraphQL Owner-only path can mutate workspace-scope secrets
-- Frontend authz (`withWorkspaceAuth`): Owner-role-only on the GraphQL `putSecret`/`deleteSecret` mutations — the UI gate
-- Write-only model: a stored value is never returned by `/secrets/list` or the UI after the initial save. The only path that surfaces values is `/secrets/spawn` (poller-token only, single call per session start)
+For everything else (adding / rotating secrets, capturing a plaintext value from the user without it touching chat, REST authz model, scope semantics), see the `secret-receiver` skill: `$CLAUDE_CONFIG_DIR/skills/secret-receiver/SKILL.md`. Direct users to the platform UI (`/settings/secrets`, `/channels/<id>`, `/pollers/<id>`) for normal entry — REST `PUT /secrets` from a poller token is poller-scope only ([teamvibe.ai#212](https://github.com/teamvibeai/teamvibe.ai/issues/212), [teamvibe.ai#213](https://github.com/teamvibeai/teamvibe.ai/issues/213)).
 
 ## Memory & Persistence
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,60 @@ Your session's current thread is encoded in the inbox path: `.inbox/SESSION:CHAN
 
 If `$PERSISTENT_STORAGE_PATH` is set, you can use it for files that should persist across sessions (e.g., caches, downloaded tools). The `$PERSISTENT_STORAGE_PATH/bin` directory is in your PATH.
 
+## Secrets
+
+The platform provides a per-spawn secrets envelope auto-injected into your `process.env` before each session starts. Three scopes merge into one env map with **channel > workspace > poller** precedence — a name at a higher scope overrides the same name at lower ones.
+
+### Reading secrets
+
+Use `process.env` directly — no extra calls needed in the normal path:
+
+```bash
+$YOUR_API_KEY
+```
+
+To discover what's *registered* at the platform (names + scopes only, never values), use the Poller API list endpoints with your existing token:
+
+```bash
+# Replace SCOPE with: poller | workspace | channel
+curl -H "Authorization: Bearer $TEAMVIBE_POLLER_TOKEN" \
+  "$TEAMVIBE_API_URL/secrets/list?scope=workspace&scopeId=$TEAMVIBE_WORKSPACE_ID"
+
+# channel scope additionally requires channelId:
+curl -H "Authorization: Bearer $TEAMVIBE_POLLER_TOKEN" \
+  "$TEAMVIBE_API_URL/secrets/list?scope=channel&scopeId=$TEAMVIBE_WORKSPACE_ID&channelId=$TEAMVIBE_CHANNEL_ID"
+```
+
+Note: `process.env` may also carry values from the **poller's local `.env` file** (host-level config loaded at poller startup). If a name appears in env but not in any `/secrets/list` response, it's coming from that local file — not from the platform — and isn't manageable via the API.
+
+### Adding / updating secrets
+
+**Do not POST plaintext values through Slack chat or a curl-with-poller-token from a user-facing session.** Plaintext belongs nowhere in the conversation transcript.
+
+When a user wants to add or rotate a secret, route them to the platform UI, which masks the value input, enforces Owner-only RBAC, and clears the form on submit:
+
+- Workspace-scope: `/settings/secrets`
+- Channel-scope: `/channels/<channelId>` (Secrets section)
+- Poller-scope: `/pollers/<pollerId>` (Secrets section)
+
+A `secret` skill is on the roadmap — it'll open a Slack-anchored modal via HTTPS tunnel so the user can submit a value without leaving Slack, and without the plaintext entering the conversation. Until that skill ships, the platform UI is the canonical entry point for user-driven secret creation.
+
+Direct REST `PUT /secrets` calls with the poller token *do* work (machine-entity workspace-boundary auth, not Owner-role gated), but reserve them for:
+
+- Migration scripts (importing from a legacy `.env`)
+- Automated rotation (regenerate-and-store flows)
+- One-off operational fixes where no user value entry is involved
+
+Never for a value the user is typing at you in chat.
+
+### Trust model — quick reference
+
+- Values: SSM SecureString at `/teamvibe/secret/<scope>/<scopeId>[/<channelId>]/<name>` (KMS-encrypted at rest)
+- Metadata (name, expiresAt, audit fields): DDB `Secret` entity
+- Backend authz (`authorizeScope`): poller-token → workspace boundary via `PollerAssignment` or `ownerWorkspaceId` match
+- Frontend authz (`withWorkspaceAuth`): Owner-role-only on the GraphQL `putSecret`/`deleteSecret` mutations — the UI gate
+- Write-only model: a stored value is never returned by `/secrets/list` or the UI after the initial save. The only path that surfaces values is `/secrets/spawn` (poller-token only, single call per session start)
+
 ## Memory & Persistence
 
 Your working directory is a git repo. Changes are pushed after each session, but

--- a/skills/secret-receiver/SKILL.md
+++ b/skills/secret-receiver/SKILL.md
@@ -1,6 +1,6 @@
 # Secret Receiver Skill
 
-Receive secrets (API tokens, credentials) from users securely via a temporary HTTP form tunneled through localtunnel. Submitted values are stored in macOS Keychain.
+Receive secrets (API tokens, credentials) from users securely via a temporary HTTP form tunneled through localtunnel. Submitted values are written to a 0600-mode file the spawning agent can read — **OS-agnostic**, no dependency on macOS Keychain, Linux `secret-tool`, or any other platform-specific store.
 
 ## How It Works
 
@@ -8,16 +8,20 @@ Receive secrets (API tokens, credentials) from users securely via a temporary HT
 2. Agent runs `npx localtunnel --port PORT` to create a temporary public HTTPS URL
 3. Agent sends the URL to the user (e.g. via Slack)
 4. User opens the URL, enters the secret, and submits
-5. Server saves the secret to macOS Keychain and shuts down
+5. Server writes the secret to a 0600-mode file (path is announced on stdout), prints a `TOKEN_RECEIVED <path>` line, returns the success page, and shuts down 2s later
+6. Agent reads the file directly into the consumer (e.g. `curl --data-binary @<path>`), then deletes the file
 
-The secret never passes through Slack or any chat — it goes directly from the user's browser to the agent's machine via an encrypted tunnel.
+The secret never passes through Slack or any chat — it goes directly from the user's browser to the agent's machine via an encrypted tunnel. The plaintext value also never appears on the server's stdout — only the file path does, so the agent's Bash invocation can capture stdout safely without leaking the value into LLM context.
 
 ## Usage
 
 ### Starting the server
 
 ```bash
-node skills/shared/secret-receiver/server.mjs --service "gitlab.com" --title "GitLab Token" --description "Paste your Personal Access Token"
+node $CLAUDE_CONFIG_DIR/skills/secret-receiver/server.mjs \
+  --service "gitlab.com" \
+  --title "GitLab Token" \
+  --description "Paste your Personal Access Token"
 ```
 
 ### Parameters
@@ -25,10 +29,10 @@ node skills/shared/secret-receiver/server.mjs --service "gitlab.com" --title "Gi
 | Parameter | Default | Description |
 |---|---|---|
 | `--port` | `3456` | Local HTTP server port |
-| `--service` | (required) | Keychain service name (used as lookup key) |
+| `--service` | (required) | Display label shown on the form page (no longer a keychain key) |
 | `--title` | `"Secret"` | Form page title |
 | `--description` | `""` | Help text shown above the input field |
-| `--account` | `jarvis` | Keychain account name |
+| `--out-file` | random path under `os.tmpdir()` | Where to write the captured value (0600 mode). Override when you want a specific path, e.g. tmpfs |
 
 ### Starting the tunnel
 
@@ -37,41 +41,109 @@ npx --yes localtunnel --port 3456
 # Output: your url is: https://xyz-random.loca.lt
 ```
 
-### Retrieving stored secrets
+### Discovering the output path
 
-```bash
-security find-generic-password -s "SERVICE_NAME" -w
+On startup the server prints two lines to stdout:
+
+```
+SERVER_READY on port 3456
+OUT_FILE /var/folders/.../secret-receiver-ab12cd34.txt
 ```
 
-Example:
-```bash
-GITLAB_TOKEN=$(security find-generic-password -s "gitlab.com" -w)
-curl -H "PRIVATE-TOKEN: $GITLAB_TOKEN" https://gitlab.com/api/v4/projects
+On successful form submission it prints:
+
 ```
+TOKEN_RECEIVED /var/folders/.../secret-receiver-ab12cd34.txt
+```
+
+Use the announced path — don't reconstruct it.
+
+### Consuming the captured value
+
+The plaintext lives in the output file with 0600 perms (owner-only). Read it into the consumer in a way that doesn't echo the value to the shell or to stdout. Two cross-platform options:
+
+```bash
+# Option A — node to construct a JSON body from the file + post
+node -e '
+  const fs = require("fs");
+  const v = fs.readFileSync(process.argv[1], "utf8");
+  process.stdout.write(JSON.stringify({
+    scope: "poller",
+    scopeId: process.env.TEAMVIBE_POLLER_ID,
+    name: "GITLAB_TOKEN",
+    value: v,
+  }));
+' /var/folders/.../secret-receiver-ab12cd34.txt |
+  curl -X PUT \
+    -H "Authorization: Bearer $TEAMVIBE_POLLER_TOKEN" \
+    -H "Content-Type: application/json" \
+    --data-binary @- \
+    "$TEAMVIBE_API_URL/secrets"
+
+# Option B — jq, if it's on the host
+jq -Rs --arg scope poller --arg scopeId "$TEAMVIBE_POLLER_ID" --arg name GITLAB_TOKEN \
+  '{scope: $scope, scopeId: $scopeId, name: $name, value: .}' \
+  /var/folders/.../secret-receiver-ab12cd34.txt |
+  curl -X PUT \
+    -H "Authorization: Bearer $TEAMVIBE_POLLER_TOKEN" \
+    -H "Content-Type: application/json" \
+    --data-binary @- \
+    "$TEAMVIBE_API_URL/secrets"
+
+# Delete the file immediately after the POST resolves
+rm /var/folders/.../secret-receiver-ab12cd34.txt
+```
+
+Avoid `value=$(cat <file>)` — that pulls the plaintext into the shell environment and any subsequent `set -x` / `env` / process listing leaks it.
 
 ## Notes
 
 - **Localtunnel interstitial:** The first visit shows a "Friendly Reminder" page. The user must click "Click to Continue" or enter their IP address to proceed.
-- **macOS only:** Uses `security` CLI (macOS Keychain). Won't work on Linux without modification.
-- **One-shot:** The server automatically shuts down after receiving one secret.
-- **`-U` flag:** If a keychain entry with the same service name already exists, it will be updated (not duplicated).
-- **Security:** The tunnel URL is random and short-lived. The server only accepts one submission before shutting down.
+- **Cross-platform:** Works on macOS, Linux, and Windows (Node's `fs` works everywhere; `chmod` is a no-op on Windows but the file still inherits the owner's user ACL).
+- **One-shot:** The server automatically shuts down 2s after receiving a value. The output file persists until the agent deletes it — clean up as soon as the value is consumed.
+- **Concurrent runs:** Default `--out-file` is randomly named, so multiple receiver instances on the same host don't collide on the same path.
+- **Security:** The tunnel URL is random and short-lived. The server only accepts one submission before shutting down. The plaintext is written to a single 0600-mode file and never to the server's stdout.
 
 ## Typical Agent Workflow
 
-```javascript
-// 1. Start server in background
-// node secret-receiver/server.mjs --service "gitlab.com" --title "GitLab Token" &
+```bash
+# 1. Start server in background, capture its stdout to grep the path
+node $CLAUDE_CONFIG_DIR/skills/secret-receiver/server.mjs \
+  --service "gitlab.com" --title "GitLab Token" > /tmp/sr.log 2>&1 &
+SR_PID=$!
 
-// 2. Start tunnel
-// npx localtunnel --port 3456
-// -> capture the URL
+# 2. Start tunnel
+npx --yes localtunnel --port 3456 > /tmp/lt.log 2>&1 &
+LT_PID=$!
+URL=$(timeout 10 grep -o 'https://[^ ]*' <(tail -F /tmp/lt.log) | head -1)
 
-// 3. Send URL to user via Slack/chat
+# 3. Send URL to user via Slack (via the slack MCP tool)
 
-// 4. Wait for TOKEN_SAVED in stdout or check keychain:
-// security find-generic-password -s "gitlab.com" -w
+# 4. Wait for TOKEN_RECEIVED on the server's stdout
+wait $SR_PID
+OUT=$(grep -o 'TOKEN_RECEIVED .*' /tmp/sr.log | tail -1 | awk '{print $2}')
 
-// 5. Clean up (server auto-exits, kill tunnel)
-// pkill -f localtunnel
+# 5. Pipe straight into the consumer (here: PUT /secrets at poller scope).
+#    See "Consuming the captured value" above — never use $(cat) or -d
+#    with the file contents, they pull plaintext through the shell env.
+node -e '
+  const fs = require("fs");
+  const v = fs.readFileSync(process.argv[1], "utf8");
+  process.stdout.write(JSON.stringify({
+    scope: "poller",
+    scopeId: process.env.TEAMVIBE_POLLER_ID,
+    name: "GITLAB_TOKEN",
+    value: v,
+  }));
+' "$OUT" |
+  curl -X PUT \
+    -H "Authorization: Bearer $TEAMVIBE_POLLER_TOKEN" \
+    -H "Content-Type: application/json" \
+    --data-binary @- \
+    "$TEAMVIBE_API_URL/secrets"
+
+# 6. Clean up
+rm "$OUT"
+kill $LT_PID 2>/dev/null
+rm /tmp/sr.log /tmp/lt.log
 ```

--- a/skills/secret-receiver/SKILL.md
+++ b/skills/secret-receiver/SKILL.md
@@ -96,6 +96,16 @@ rm /var/folders/.../secret-receiver-ab12cd34.txt
 
 Avoid `value=$(cat <file>)` — that pulls the plaintext into the shell environment and any subsequent `set -x` / `env` / process listing leaks it.
 
+## Where the captured value can land
+
+This skill only captures the value — it doesn't pick a destination. Decide that *before* you spin the form up:
+
+- **Poller-scope** (e.g. an agent rotating its own GitLab PAT): `PUT $TEAMVIBE_API_URL/secrets` with `scope: "poller"` and `scopeId: $TEAMVIBE_POLLER_ID`. This is the only platform write the REST API accepts from a poller-token Bearer; see [teamvibe.ai#212](https://github.com/teamvibeai/teamvibe.ai/issues/212).
+- **Workspace-scope**: REST is **denied** for poller tokens. The platform UI (`/settings/secrets`, Owner-role only via `withWorkspaceAuth` on the GraphQL `Mutation.putSecret`) is the canonical write path. If you've already captured a value via this skill and the user wants it in workspace scope, surface the file path in a follow-up Slack message so they can `cat <path> | pbcopy` (or equivalent) and paste it into the UI themselves, then `rm` the file.
+- **Channel-scope**: REST accepts the write only if the target Channel row exists and isn't soft-deleted ([teamvibe.ai#213](https://github.com/teamvibeai/teamvibe.ai/issues/213)). If the channel exists, the consumer pattern above with `scope: "channel"`, `scopeId: $TEAMVIBE_WORKSPACE_ID`, `channelId: <id>` works. If it doesn't exist yet, route the user to `/channels/<id>` (UI, Owner-only).
+
+In all cases the platform value is **write-only after save** — no list endpoint or UI surface returns the plaintext later. It only reappears in agent `process.env` via the per-spawn injection.
+
 ## Notes
 
 - **Localtunnel interstitial:** The first visit shows a "Friendly Reminder" page. The user must click "Click to Continue" or enter their IP address to proceed.

--- a/skills/secret-receiver/SKILL.md
+++ b/skills/secret-receiver/SKILL.md
@@ -1,0 +1,77 @@
+# Secret Receiver Skill
+
+Receive secrets (API tokens, credentials) from users securely via a temporary HTTP form tunneled through localtunnel. Submitted values are stored in macOS Keychain.
+
+## How It Works
+
+1. Agent starts a local Node.js HTTP server with a simple form
+2. Agent runs `npx localtunnel --port PORT` to create a temporary public HTTPS URL
+3. Agent sends the URL to the user (e.g. via Slack)
+4. User opens the URL, enters the secret, and submits
+5. Server saves the secret to macOS Keychain and shuts down
+
+The secret never passes through Slack or any chat — it goes directly from the user's browser to the agent's machine via an encrypted tunnel.
+
+## Usage
+
+### Starting the server
+
+```bash
+node skills/shared/secret-receiver/server.mjs --service "gitlab.com" --title "GitLab Token" --description "Paste your Personal Access Token"
+```
+
+### Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `--port` | `3456` | Local HTTP server port |
+| `--service` | (required) | Keychain service name (used as lookup key) |
+| `--title` | `"Secret"` | Form page title |
+| `--description` | `""` | Help text shown above the input field |
+| `--account` | `jarvis` | Keychain account name |
+
+### Starting the tunnel
+
+```bash
+npx --yes localtunnel --port 3456
+# Output: your url is: https://xyz-random.loca.lt
+```
+
+### Retrieving stored secrets
+
+```bash
+security find-generic-password -s "SERVICE_NAME" -w
+```
+
+Example:
+```bash
+GITLAB_TOKEN=$(security find-generic-password -s "gitlab.com" -w)
+curl -H "PRIVATE-TOKEN: $GITLAB_TOKEN" https://gitlab.com/api/v4/projects
+```
+
+## Notes
+
+- **Localtunnel interstitial:** The first visit shows a "Friendly Reminder" page. The user must click "Click to Continue" or enter their IP address to proceed.
+- **macOS only:** Uses `security` CLI (macOS Keychain). Won't work on Linux without modification.
+- **One-shot:** The server automatically shuts down after receiving one secret.
+- **`-U` flag:** If a keychain entry with the same service name already exists, it will be updated (not duplicated).
+- **Security:** The tunnel URL is random and short-lived. The server only accepts one submission before shutting down.
+
+## Typical Agent Workflow
+
+```javascript
+// 1. Start server in background
+// node secret-receiver/server.mjs --service "gitlab.com" --title "GitLab Token" &
+
+// 2. Start tunnel
+// npx localtunnel --port 3456
+// -> capture the URL
+
+// 3. Send URL to user via Slack/chat
+
+// 4. Wait for TOKEN_SAVED in stdout or check keychain:
+// security find-generic-password -s "gitlab.com" -w
+
+// 5. Clean up (server auto-exits, kill tunnel)
+// pkill -f localtunnel
+```

--- a/skills/secret-receiver/server.mjs
+++ b/skills/secret-receiver/server.mjs
@@ -1,6 +1,15 @@
 import http from 'node:http';
-import { execFileSync } from 'node:child_process';
+import { writeFileSync, chmodSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import { parseArgs } from 'node:util';
+
+// OS-agnostic — does NOT depend on macOS `security` CLI, Linux
+// `secret-tool`, Windows credential APIs, or any other platform-specific
+// storage. Captures the value to a 0600-mode file (or a caller-supplied
+// path) so the spawning agent can read it via Bash + pipe-to-curl
+// without ever putting the plaintext into LLM context.
 
 const { values: args } = parseArgs({
   options: {
@@ -8,12 +17,12 @@ const { values: args } = parseArgs({
     service: { type: 'string' },
     title: { type: 'string', default: 'Secret' },
     description: { type: 'string', default: '' },
-    account: { type: 'string', default: 'jarvis' },
+    'out-file': { type: 'string' },
   },
 });
 
 if (!args.service) {
-  console.error('Error: --service is required (keychain service name)');
+  console.error('Error: --service is required (label shown on the form)');
   process.exit(1);
 }
 
@@ -21,13 +30,25 @@ const PORT = parseInt(args.port, 10);
 const SERVICE = args.service;
 const TITLE = args.title;
 const DESCRIPTION = args.description;
-const ACCOUNT = args.account;
+
+// Default to a temp file with a random suffix so the agent can run
+// multiple instances concurrently without collisions. Override via
+// --out-file for tighter control (e.g., a tmpfs-mounted path).
+const OUT_FILE =
+  args['out-file'] ??
+  join(tmpdir(), `secret-receiver-${randomBytes(8).toString('hex')}.txt`);
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[c]);
+}
 
 function htmlPage(body) {
   return `<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${TITLE}</title>
+<title>${escapeHtml(TITLE)}</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; }
   body {
@@ -71,8 +92,8 @@ function htmlPage(body) {
 }
 
 const FORM_HTML = htmlPage(`
-  <h2>${TITLE}</h2>
-  ${DESCRIPTION ? `<p class="desc">${DESCRIPTION}</p>` : ''}
+  <h2>${escapeHtml(TITLE)}</h2>
+  ${DESCRIPTION ? `<p class="desc">${escapeHtml(DESCRIPTION)}</p>` : ''}
   <form method="POST" action="/save">
     <div class="field">
       <input type="password" id="secret" name="secret" placeholder="Paste secret here..." required autofocus>
@@ -83,14 +104,14 @@ const FORM_HTML = htmlPage(`
         this.textContent = isPassword ? '🙈' : '👁';
       ">👁</button>
     </div>
-    <button type="submit">Save to Keychain</button>
+    <button type="submit">Submit</button>
   </form>
 `);
 
 const OK_HTML = htmlPage(`
   <div class="ok">
-    <h2>✓ Saved</h2>
-    <p>Secret stored in Keychain as <code>${SERVICE}</code>.<br>You can close this page.</p>
+    <h2>✓ Received</h2>
+    <p>Secret received. You can close this page — the agent will pick it up shortly.</p>
   </div>
 `);
 
@@ -115,11 +136,16 @@ const server = http.createServer((req, res) => {
       }
 
       try {
-        // -U updates if exists, creates if not
-        execFileSync('security', [
-          'add-generic-password', '-a', ACCOUNT, '-s', SERVICE, '-w', secret, '-U',
-        ]);
-        console.log('TOKEN_SAVED');
+        // Ensure parent dir exists; cheap idempotent guard for callers
+        // who hand us a custom path under a non-existent directory.
+        mkdirSync(dirname(OUT_FILE), { recursive: true });
+        writeFileSync(OUT_FILE, secret, { encoding: 'utf8' });
+        // 0600 — readable only by the owner. On Windows the chmod is a
+        // no-op but the file still inherits the process's user ACL.
+        try { chmodSync(OUT_FILE, 0o600); } catch { /* best-effort */ }
+        // The agent reads this line over stdout to discover the file
+        // path — the plaintext never appears in stdout.
+        console.log(`TOKEN_RECEIVED ${OUT_FILE}`);
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(OK_HTML);
         setTimeout(() => {
@@ -140,5 +166,8 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(PORT, () => {
+  // Print both lines so the agent's stdout parser can capture them
+  // before the form ever loads.
   console.log(`SERVER_READY on port ${PORT}`);
+  console.log(`OUT_FILE ${OUT_FILE}`);
 });

--- a/skills/secret-receiver/server.mjs
+++ b/skills/secret-receiver/server.mjs
@@ -1,0 +1,144 @@
+import http from 'node:http';
+import { execFileSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+
+const { values: args } = parseArgs({
+  options: {
+    port: { type: 'string', default: '3456' },
+    service: { type: 'string' },
+    title: { type: 'string', default: 'Secret' },
+    description: { type: 'string', default: '' },
+    account: { type: 'string', default: 'jarvis' },
+  },
+});
+
+if (!args.service) {
+  console.error('Error: --service is required (keychain service name)');
+  process.exit(1);
+}
+
+const PORT = parseInt(args.port, 10);
+const SERVICE = args.service;
+const TITLE = args.title;
+const DESCRIPTION = args.description;
+const ACCOUNT = args.account;
+
+function htmlPage(body) {
+  return `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${TITLE}</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    max-width: 440px; margin: 60px auto; padding: 20px;
+    background: #f5f5f5; color: #1a1a1a;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1a1a; color: #e5e5e5; }
+    input { background: #2a2a2a; color: #e5e5e5; border-color: #444; }
+    button { background: #6b4fbb; }
+    button:hover { background: #7b5fcb; }
+    .toggle { color: #aaa; }
+    .toggle:hover { color: #ccc; }
+  }
+  h2 { margin: 0 0 8px; }
+  p.desc { color: #666; font-size: 14px; margin: 0 0 16px; }
+  @media (prefers-color-scheme: dark) { p.desc { color: #999; } }
+  .field { position: relative; margin-bottom: 16px; }
+  input {
+    width: 100%; padding: 12px 44px 12px 12px; font-size: 16px;
+    border: 2px solid #ddd; border-radius: 8px; outline: none;
+  }
+  input:focus { border-color: #6b4fbb; }
+  .toggle {
+    position: absolute; right: 12px; top: 50%; transform: translateY(-50%);
+    background: none; border: none; cursor: pointer; font-size: 18px;
+    color: #666; padding: 4px;
+  }
+  .toggle:hover { color: #333; }
+  button[type="submit"] {
+    background: #6b4fbb; color: white; border: none;
+    padding: 12px 32px; font-size: 16px; border-radius: 8px;
+    cursor: pointer; width: 100%;
+  }
+  button[type="submit"]:hover { background: #5a3fa8; }
+  .ok { text-align: center; margin-top: 40px; }
+  .ok h2 { color: #22c55e; }
+</style>
+</head><body>${body}</body></html>`;
+}
+
+const FORM_HTML = htmlPage(`
+  <h2>${TITLE}</h2>
+  ${DESCRIPTION ? `<p class="desc">${DESCRIPTION}</p>` : ''}
+  <form method="POST" action="/save">
+    <div class="field">
+      <input type="password" id="secret" name="secret" placeholder="Paste secret here..." required autofocus>
+      <button type="button" class="toggle" onclick="
+        const inp = document.getElementById('secret');
+        const isPassword = inp.type === 'password';
+        inp.type = isPassword ? 'text' : 'password';
+        this.textContent = isPassword ? '🙈' : '👁';
+      ">👁</button>
+    </div>
+    <button type="submit">Save to Keychain</button>
+  </form>
+`);
+
+const OK_HTML = htmlPage(`
+  <div class="ok">
+    <h2>✓ Saved</h2>
+    <p>Secret stored in Keychain as <code>${SERVICE}</code>.<br>You can close this page.</p>
+  </div>
+`);
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(FORM_HTML);
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/save') {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      const params = new URLSearchParams(body);
+      const secret = params.get('secret')?.trim();
+
+      if (!secret) {
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('Missing secret');
+        return;
+      }
+
+      try {
+        // -U updates if exists, creates if not
+        execFileSync('security', [
+          'add-generic-password', '-a', ACCOUNT, '-s', SERVICE, '-w', secret, '-U',
+        ]);
+        console.log('TOKEN_SAVED');
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(OK_HTML);
+        setTimeout(() => {
+          server.close();
+          process.exit(0);
+        }, 2000);
+      } catch (err) {
+        console.error('SAVE_ERROR:', err.message);
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Failed to save: ' + err.message);
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`SERVER_READY on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary

Adds a `## Secrets` section to base-brain `CLAUDE.md`. Covers:

- Auto-injection into `process.env` at each session spawn
- Three scopes (`poller`, `workspace`, `channel`) and their precedence (channel > workspace > poller)
- Discovery via `/secrets/list` with Bearer token
- The boundary between platform-managed secrets (DDB+SSM) and local `.env` host config (both land in `process.env`, only the former is manageable via API)
- **Write path routed through platform UI, not direct curl** — and a forward reference to a future `secret` skill that will open a Slack-anchored modal via HTTPS tunnel so plaintext values never enter the conversation transcript
- Trust model quick reference (SSM SecureString, KMS, write-only-post-save, two-layer authz)

## Why

Reported gap: another poller on production told its user "I can't see secrets and can't manage them." Root cause = zero `secret` mentions in this `CLAUDE.md`, so agents had no path to discover the auto-injection mechanism or the REST list endpoint. End-to-end verified in this VibeKeeper session:

- Token-auth `/secrets/spawn` returns env map per scope: confirmed
- `/secrets/list?scope=…` returns names + scopes (no values): confirmed
- Full PUT → LIST → DELETE cycle at poller and workspace scopes: HTTP 200/204
- One platform-managed secret `AAA` was indeed in env; CLOCKIFY/FAKTUROID/TRADING212 keys turned out to come from the local `.env`, not the platform — that distinction is now explicit in the docs

## Per Jakub directive

> "Pridávání secretu bychom měli řešit přes secret skill (otevření input formuláře přes http tunnel)"

The new section codifies that intent: direct `PUT /secrets` calls are documented as machine-side (migration, rotation) only — user-driven secret entry routes through platform UI today and through the upcoming `secret` skill once that ships.

## Test plan

- [ ] Render check: section appears between `## Persistent Storage` and `## Memory & Persistence`, consistent heading depth and bullet style with the rest of the file
- [ ] Cross-reference check: scope precedence + endpoint names match `packages/modules-teamvibe/src/hooks/poller-secrets.ts` on `main`
- [ ] No new claims about base-brain behavior that contradict the existing Channel Brain Isolation rules

## Blast radius

Pure documentation; +54 lines additive; no behavior change. Affects all pollers but only by giving them more context, not by changing their runtime contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)