### PR TITLE
fix(slack): warn on markdown pipe table in text field (closes tv.ai#224)

### DIFF
--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -172,6 +172,34 @@ async function computeMissingTagWarning(channel, threadTs, text, justSentTs = nu
   }
 }
 
+// Returns a warning hint object if outgoing `text` contains a markdown pipe
+// table (2+ consecutive `^\s*\|.*\|.*$` lines), or null. Slack renders pipe
+// tables in the `text` field as monospace ASCII without column alignment;
+// `blocks: [{type: 'markdown', ...}]` renders them correctly.
+// Deterministic — no LLM, no API call. See teamvibeai/teamvibe.ai#224.
+function computePipeTableWarning(text) {
+  if (!text || typeof text !== 'string') return null
+  // Strip triple-fenced code blocks — pipe-tables inside fences are quoted
+  // material (instructions, samples), not table rendering.
+  const stripped = text.replace(/```[\s\S]*?```/g, '')
+  const lines = stripped.split('\n')
+  let consecutive = 0
+  for (const line of lines) {
+    if (/^\s*\|.*\|.*$/.test(line)) {
+      consecutive++
+      if (consecutive >= 2) {
+        return {
+          code: 'ascii_table_in_text',
+          detail: "Detected markdown table syntax in `text` field. Slack renders pipe tables as monospace ASCII without column alignment. Use a `markdown` block via `blocks: [{type: 'markdown', text: '...'}]` for proper rendering.",
+        }
+      }
+    } else {
+      consecutive = 0
+    }
+  }
+  return null
+}
+
 // Resolve a Slack user_id to a friendly display name. Caches per-process for
 // the session lifetime since display names rarely change mid-conversation.
 const _userInfoCache = new Map()
@@ -490,8 +518,10 @@ async function handleTool(name, args) {
       // lookback skips the just-sent message (self) — eliminates the race
       // where self appears as last_speaker. See teamvibeai/teamvibe.ai#108.
       const warning = await computeMissingTagWarning(channel, thread_ts, args.text, result.ts)
+      const tableWarning = computePipeTableWarning(args.text)
+      const warnings = [warning, tableWarning].filter(Boolean)
       const response = { ok: true, ts: result.ts }
-      if (warning) response.warnings = [warning]
+      if (warnings.length) response.warnings = warnings
       return response
     }
 


### PR DESCRIPTION
## Summary

Mirror pattern z [teamvibe.ai#108](https://github.com/teamvibeai/teamvibe.ai/issues/108) (`missing_recipient_tag` shipped via #136): když `send_message` dostane markdown pipe-table syntax v `text` poli, vrátíme `warnings[]` s `code: ascii_table_in_text`. Agent sám rozhodne (warning, ne block) — legitimní use cases existují (broadcast s minimal table, status update).

Closes [teamvibeai/teamvibe.ai#224](https://github.com/teamvibeai/teamvibe.ai/issues/224).

## Implementation

`computePipeTableWarning(text)` — synchronní, deterministický, +31 LOC:

1. **Gate** — `if (!text)` → null (blocks-only call neovlivněn)
2. **Strip** triple-fenced code blocks (`/```[\s\S]*?```/g`) — pipe tables uvnitř ``` jsou quoted material (instructions, samples)
3. **Scan** stripped text po řádcích — pokud najdeme 2+ consecutive `^\s*\|.*\|.*$`, vrátíme warning hint

Wired do `send_message` handleru jako součást existujícího `warnings[]` arraye (collected vedle `computeMissingTagWarning`).

## Acceptance criteria mapping

- [x] **AC1**: 2+ consecutive `^\s*\|.*\|.*$` lines → `code: ascii_table_in_text`
- [x] **AC2**: Pouze `blocks` (bez `text`) → guard `if (!text)` na řádku 1
- [x] **AC3**: Text uvnitř ``` code-fences vyloučen — `replace(/```[\s\S]*?```/g, '')` před scan
- [x] **AC4**: `blocks: [{type: 'markdown'}]` self-only není ovlivněn (gate na `args.text`)
- [x] **AC5**: Žádné LLM — čistý regex

## Test plan

Lokálně ověřeno 12 test cases (inline node eval — žádná test infra v repo):

- [x] null/empty/non-string text → null
- [x] plain text bez pipes → null
- [x] single pipe line → null (vyžaduje 2+ consecutive)
- [x] 2+ pipe lines → fire (AC1)
- [x] table inside ```...``` → null (AC3)
- [x] table after closing fence → fire
- [x] indented pipe lines (leading spaces) → fire
- [x] interleaved non-table line breaks chain → null

## Tier

**Tier 1** (poller-brain `mcp/slack.mjs`, NE base-brain skills/memory/*). +31 LOC, jeden file. Per [MEM-35] carve-out se nevztahuje. Mirror pattern z #136.

DevGuru consult plan ack'd Jakubem 2026-06-26 (D0ASY83CV0W ts 1782452920).

🤖 Generated with [Claude Code](https://claude.com/claude-code)