### PR TITLE
fix(memory): resolve brain root deterministically (#189, #192)

### DIFF
--- a/skills/memory/scripts/lib/brain-root.ts
+++ b/skills/memory/scripts/lib/brain-root.ts
@@ -1,0 +1,72 @@
+/**
+ * Resolve the brain repo root deterministically.
+ *
+ * Memory scripts (log-write, mem-write) write to `memory/TODAY.md` and
+ * `memory/MEM_REGISTRY.md`. When invoked with a relative path, those files
+ * resolve against `process.cwd()` — so if a session has chdir'd into a
+ * subdirectory (skills/, .local/tmp/, etc.) the scripts will silently
+ * create a nested `memory/` tree under that subdir, splitting the daily log
+ * and forking the MEM key counter off the global registry.
+ *
+ * Reference: poller-brain#189 (feedback/bug/high), #192, #194, #195.
+ *
+ * Resolution order:
+ *   1. `BRAIN_ROOT` env var (explicit escape hatch) — must point at a dir
+ *      containing both `CLAUDE.md` and `memory/`.
+ *   2. Walk up from `process.cwd()` looking for the same dual marker.
+ *   3. Throw with an actionable message.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+let cached: string | null = null;
+
+function hasBrainMarkers(dir: string): boolean {
+  return (
+    fs.existsSync(path.join(dir, "CLAUDE.md")) &&
+    fs.existsSync(path.join(dir, "memory"))
+  );
+}
+
+function walkUp(start: string): string | null {
+  let dir = path.resolve(start);
+  while (true) {
+    if (hasBrainMarkers(dir)) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+export function resolveBrainRoot(): string {
+  if (cached) return cached;
+
+  const fromEnv = process.env.BRAIN_ROOT;
+  if (fromEnv) {
+    const abs = path.resolve(fromEnv);
+    if (!hasBrainMarkers(abs)) {
+      throw new Error(
+        `BRAIN_ROOT="${fromEnv}" does not look like a brain repo ` +
+          `(missing CLAUDE.md and/or memory/). Unset BRAIN_ROOT or point it at a brain dir.`
+      );
+    }
+    cached = abs;
+    return abs;
+  }
+
+  const found = walkUp(process.cwd());
+  if (!found) {
+    throw new Error(
+      `Brain root not found. Walked up from cwd="${process.cwd()}" looking for a ` +
+        `directory containing both CLAUDE.md and memory/. ` +
+        `Run this script from inside a brain repo, or set BRAIN_ROOT to its absolute path.`
+    );
+  }
+  cached = found;
+  return found;
+}
+
+export function brainPath(...segments: string[]): string {
+  return path.join(resolveBrainRoot(), ...segments);
+}

--- a/skills/memory/scripts/log-write.ts
+++ b/skills/memory/scripts/log-write.ts
@@ -14,14 +14,13 @@
  */
 
 import * as fs from "fs";
-import * as path from "path";
+import { brainPath } from "./lib/brain-root.js";
 
-const TODAY_PATH = "memory/TODAY.md";
+const TODAY_PATH = brainPath("memory/TODAY.md");
 
 function ensureToday(): void {
   const today = new Date().toISOString().slice(0, 10);
   if (!fs.existsSync(TODAY_PATH)) {
-    fs.mkdirSync(path.dirname(TODAY_PATH), { recursive: true });
     fs.writeFileSync(TODAY_PATH, `# ${today}\n\n`);
     return;
   }

--- a/skills/memory/scripts/mem-write.ts
+++ b/skills/memory/scripts/mem-write.ts
@@ -15,10 +15,10 @@
  */
 
 import * as fs from "fs";
-import * as path from "path";
+import { brainPath } from "./lib/brain-root.js";
 
-const REGISTRY_PATH = "memory/MEM_REGISTRY.md";
-const TODAY_PATH = "memory/TODAY.md";
+const REGISTRY_PATH = brainPath("memory/MEM_REGISTRY.md");
+const TODAY_PATH = brainPath("memory/TODAY.md");
 
 const REGISTRY_HEADER = `# MEM Registry
 
@@ -48,14 +48,12 @@ function getNextKey(): number {
 
 function ensureRegistry(): void {
   if (!fs.existsSync(REGISTRY_PATH)) {
-    fs.mkdirSync(path.dirname(REGISTRY_PATH), { recursive: true });
     fs.writeFileSync(REGISTRY_PATH, REGISTRY_HEADER);
   }
 }
 
 function ensureToday(): void {
   if (!fs.existsSync(TODAY_PATH)) {
-    fs.mkdirSync(path.dirname(TODAY_PATH), { recursive: true });
     const today = new Date().toISOString().slice(0, 10);
     fs.writeFileSync(TODAY_PATH, `# ${today}\n\n`);
   }


### PR DESCRIPTION
## Summary

`log-write.ts` and `mem-write.ts` previously resolved `memory/TODAY.md` and `memory/MEM_REGISTRY.md` *relative to `process.cwd()`*. A session that `chdir`'d into `skills/`, `.local/tmp/`, etc. would silently create an orphaned `memory/` tree under that subdir, splitting the daily log and re-numbering MEM keys from 1 against the global registry.

Three duplicate issues filed in the last week (#189 high-priority feedback, #192, #194, #195). Consolidation has had to recover mis-routed entries on three cycles (2026-06-20, 22, 23).

## Fix

New helper `skills/memory/scripts/lib/brain-root.ts` with `resolveBrainRoot()`:

1. **BRAIN_ROOT env var** (escape hatch — explicit-intent marker per [MEM-42])
2. **Walk up from cwd** looking for a directory containing both `CLAUDE.md` AND `memory/` (dual marker — robust against false positives)
3. **Throw** with an actionable error if neither resolves (fail loudly per #189 rec)

Both scripts now use `brainPath(\"memory/...\")` to compute absolute paths, and drop their defensive `mkdirSync` calls (the dir is guaranteed by the brain marker). Success messages now print the **absolute path** so any misroute is visible immediately.

## Test plan

Verified all four paths manually (synthetic fakebrain + this repo):

- [x] Invocation from subdir (`skills/sub/`) resolves to brain root — no orphaned nested `memory/`
- [x] Invocation from brain root unchanged (backwards-compat)
- [x] `BRAIN_ROOT` env var override works
- [x] `BRAIN_ROOT=/nonexistent` throws with helpful message
- [x] Invocation outside any brain (no markers up to /) throws cleanly

## Blast radius

Tier 2 per [MEM-35] (`skills/memory/*` in base-brain).

- DevGuru consult in `D0ASY83CV0W` ts `1782279250.040949` — 5d no ack, escalated 2026-06-29.
- @jakubknejzlik tagged for Tier 2 review.

Closes #189, #192, #194, #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)