### PR TITLE
docs(memory/consolidate): add 5c. LEARNINGS.md Gradual Reduction step (#198)

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -234,6 +234,37 @@ Add any created, updated, or deleted semantic files to `filesChanged`. Set `self
 
 If `memory/semantic/` doesn't exist or is empty, skip this step and set `selfAssessment["semantic-lifecycle-checked"]` to `true` (nothing to check).
 
+### 5c. LEARNINGS.md Gradual Reduction
+
+If `memory/core/LEARNINGS.md` exceeds 5000 bytes, perform **one** small archival per consolidation cycle. This mirrors Step 9c (CLAUDE.md reduction) but for lessons memory — without this step, LEARNINGS.md grows monotonically because promotion appends new entries but never retires resolved or superseded ones.
+
+**Preflight:** Run `wc -c memory/core/LEARNINGS.md`. If under 5000 bytes, skip this step entirely. If over 5000 bytes, proceed.
+
+1. **Identify one archival candidate** (1–3 oldest entries) in `LEARNINGS.md` that meets ANY of:
+   - Has a `[MEM-NNN]` key whose status in `memory/MEM_REGISTRY.md` is `OBSOLETE` or `REMOVED` (i.e., the lesson has already been superseded via the MEM lifecycle in Step 1c)
+   - Describes an incident/problem that has a follow-up "resolved" or "shipped" entry visible in `memory/episodic/` (i.e., the lesson was situational and no longer teaches something new)
+
+   **Never archive** an entry whose `[MEM-NNN]` is still `ACTIVE`, an entry without a MEM key, or an entry younger than 30 days.
+
+2. **Archive it:**
+   - Create (if missing) or append to `memory/episodic/archive/learnings-YYYY-Hn.md` where `Hn` is `H1` (Jan–Jun) or `H2` (Jul–Dec) of the current year. This bucket keeps archived lessons grep-searchable but out of hot-path memory.
+   - Copy the entry **verbatim** — preserve the `[MEM-NNN]` key and any inline links.
+   - Prepend a one-line header noting the archival date and reason (`obsolete-per-registry` / `superseded-by-episodic-<file>`).
+   - Remove the entry from `memory/core/LEARNINGS.md`.
+
+3. **Log it** in the markdown report under `## LEARNINGS.md Reduction`:
+   - Which entry was moved (MEM key + first 60 chars), archival reason, size delta (bytes before → after)
+   - Registry status (`OBSOLETE`/`REMOVED`) or link to the superseding episodic file
+
+4. **Constraints:**
+   - Move *at most 1 archival per cycle* — gradual reduction, not a big-bang refactor
+   - *Never* archive an entry currently referenced by `memory/SUMMARY.md` "Key Rules" section — that's a signal it's still load-bearing; downgrade the SUMMARY reference first in a future cycle
+   - If no safe candidate exists (all entries `ACTIVE` and recent), skip this step and note `no safe candidate found — LEARNINGS.md at N bytes, no archival-eligible entries` in the report. Do NOT force an archival to hit the threshold.
+
+Add `memory/core/LEARNINGS.md` and the archive file to `filesChanged` when archival fires.
+
+This ensures steady progress toward the threshold while requiring lifecycle-provenance (MEM_REGISTRY or episodic) rather than unstructured age-based deletion.
+
 ### 6. Regenerate SUMMARY.md
 
 **Always regenerate `memory/SUMMARY.md` on every consolidation run — this step is non-negotiable, even if no facts were promoted in steps 2–4.** A lightweight consolidation with zero promotions must still regenerate SUMMARY.md to ensure it reflects the current state of all memory tiers.


### PR DESCRIPTION
## Summary
- Adds Step **5c. LEARNINGS.md Gradual Reduction** to `skills/memory/consolidate/skill.md`. Mirrors Step 9c (CLAUDE.md reduction) but for `memory/core/LEARNINGS.md`.
- Bounded: at most one archival per consolidation cycle, only when LEARNINGS.md > 5000 bytes, and only for entries with `MEM_REGISTRY.md` status `OBSOLETE`/`REMOVED` or clear "superseded-by-episodic" provenance. Archived entries go to `memory/episodic/archive/learnings-YYYY-Hn.md` (grep-searchable).
- Doc-only change to the skill markdown. No code, no runtime behavior in the harness — brains pick up the new step on the next consolidation cycle.

Closes teamvibeai/poller-brain#198.

## Why this matters
Agent-reported chronic pain (`@Aiden`, self-flagged, 6+ consecutive Memory Metrics `:warning:` rows from 06-16 through 06-28). Current consolidation appends to `core/LEARNINGS.md` on every promotion but has no retirement path. In brains with active promotion, LEARNINGS.md monotonically grows past the 5000 B threshold. Every reflection since 06-15 recommends reducing it and no skill step exists to enact the reduction — channel-brain agents cannot fix the base-brain skill from their own repo.

## Design choices
- **Mirror 9c**, don't invent a new mechanism — same one-block-per-cycle discipline, same "skip if under threshold" preflight, same "no safe candidate → skip and log" fallback. Familiar shape for skill readers and evaluators.
- **Provenance-gated, not age-gated.** Archival requires a MEM lifecycle signal (`OBSOLETE`/`REMOVED`) or a superseding episodic file. This prevents the step from becoming a rubber-stamp deletion of old-but-still-load-bearing lessons.
- **Archive, don't delete.** Archived entries land in `memory/episodic/archive/learnings-YYYY-Hn.md` so grep still finds them; SUMMARY.md just stops referencing them.
- **No new `selfAssessment` key** — same reason 9c doesn't have one. `filesChanged` and the report section carry the signal; adding a schema key would require an eval-side change and grader retraining.
- **Order:** 5c runs after 5b (Semantic Lifecycle) and after 1c (MEM lifecycle sets OBSOLETE/REMOVED status), and before 6 (SUMMARY regen), so the regenerated SUMMARY reflects the reduced LEARNINGS.md.

## Risk / Tier
- **Tier 2** per [MEM-35] — touches `skills/memory/*` in the base brain, blast radius = fleet-wide consolidation flow.
- Blast radius bounded by the "at most 1 per cycle" constraint and the provenance gate. Worst realistic case: one brain archives one entry to `episodic/archive/` that a reader still wanted in `core/LEARNINGS.md` — the entry is not lost (grep-searchable), just less hot.
- 31 LOC in one skill markdown file. No selfAssessment schema change. No code change.

## DevGuru gate + escalation ([MEM-29], [MEM-35])
- Per `procedural/maintenance-workflow.md` D=3 rolling 14-day rule, DevGuru has been unavailable 5+ days across multiple pending consults (`teamvibeai/poller-brain#196`, `teamvibeai/teamvibe.ai#213`). Two-Tier Fallback conditions met.
- Escalating to `@jakubknejzlik` for merge auth on this PR.

## Test plan
- [ ] Read Step 9c and confirm 5c mirrors it structurally (preflight → identify → archive → log → constraints).
- [ ] Manually simulate 5c on a brain with LEARNINGS.md > 5000 B and at least one `OBSOLETE` MEM entry — confirm exactly one entry moves and `## LEARNINGS.md Reduction` appears in the report.
- [ ] Simulate 5c on a brain with LEARNINGS.md > 5000 B and only `ACTIVE` MEM entries — confirm `no safe candidate found` note in the report and zero file changes.
- [ ] Simulate 5c on a brain with LEARNINGS.md < 5000 B — confirm the step short-circuits at preflight.
- [ ] Verify Step 6 (Regenerate SUMMARY.md) runs after 5c so the archival is reflected in the new SUMMARY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)