### PR TITLE
Auto-improve: gap-impact-analysis

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -105,7 +105,11 @@ Produce both a markdown and JSON report in `reports/` as required by MAINTENANCE
 
 **JSON:** `reports/YYYY-MM-DD-memory-reflection.json` — populate every field:
 
-- `observations`: List specific findings from this reflection. Each entry should name a concrete memory strength, OR pair a memory gap with the *operational consequence it has already produced* in recent maintenance cycles. Gap-only observations ("X is missing", "Y is thin") do NOT qualify — they go to `processImprovements` as `[proposal]` instead. Examples:
+- `observations`: List specific findings from this reflection. Each entry should name a concrete memory strength, OR pair a memory gap with the *operational consequence it has already produced* in recent maintenance cycles. Gap-only observations ("X is missing", "Y is thin") do NOT qualify — they go to `processImprovements` as `[proposal]` instead.
+
+  **Pre-write self-check (required):** Before finalizing this list, scan every draft observation for gap-class words: `lacks`, `missing`, `thin`, `no entry for`, `gap in coverage`. For each match, confirm the item includes a specific outcome AND a date: "which caused [outcome] in [cycle] on [YYYY-MM-DD]." If you cannot supply both, move the item to `processImprovements` as `[proposal]` — do NOT leave it in `observations`. An observation with gap language but no dated consequence will fail the `gap-impact-analysis` eval criterion.
+
+  Examples:
   - "semantic/team-members.md has complete profiles for all 4 active members" — concrete strength
   - "memory/core/LEARNINGS.md has grown to 80 lines and the last 2 promotions appended new bullets rather than merging into the existing entry, creating 3 near-duplicate rules" — gap + observed consequence
   - "No procedural documentation exists for the weekly-standup workflow, which led to 4 inconsistent invocations across the last 5 standup runs" — gap + observed consequence


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** gap-impact-analysis
**Eval date:** 2026-07-04
**Overall score:** 0.9424

### Recent Eval History
- concrete-improvement-proposal: 98%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 69% <-- TARGET
- previous-recommendations-reviewed: 81%
- process-self-critique: 99%
- reduce-log-count: 86%
- semantic-naming-convention: 100%
- summary-md-regenerated: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** gap-impact-analysis
**Files modified:** skills/memory/reflect/skill.md

### What changed

Added a mandatory "pre-write self-check" step in the `observations` field guidance of the reflect skill's Output section. The check instructs agents to scan every draft observation for gap-class words (`lacks`, `missing`, `thin`, `no entry for`, `gap in coverage`) and verify that each match includes both a specific outcome and a date before it stays in `observations`. Items that fail the check must be moved to `processImprovements` as `[proposal]`.

### Why

The `gap-impact-analysis` criterion passes only when at least one `observations` entry pairs a memory gap with a specific, dated operational consequence. The historical pass rate is ~69%, meaning ~30% of qualifying reflection reports include gap-class language without the required consequence. The skill already had rules about this in Step 3 (Gap Analysis), but agents were still writing gap observations without consequences at the output stage. Adding the self-check directly at the point of writing the JSON provides a concrete, final-stage enforcement mechanism.

Report insights confirmed this failure pattern is real: pollers that pass the criterion write observations like "core/LEARNINGS.md reduction was handed to consolidation on 2026-06-29 but 5 consecutive consolidations skipped it because Step 9c only checks CLAUDE.md size" — gap + named consequence + date. The self-check codifies exactly this requirement as a step agents must complete before committing their JSON output.

### Skill Impact

**Skill:** memory/reflect — Memory self-assessment skill run during maintenance to assess memory quality, resolve contradictions, and produce a reflection report.

**Behavior change:** Agents will now perform an explicit scan of their planned `observations` list before writing the JSON report. Any observation containing gap-class language that lacks a specific dated consequence will be caught and routed to `processImprovements` instead of being left as a failing gap-only observation. This eliminates the most common failure mode for this criterion without changing how valid gap+consequence observations are written.

### Expected impact

The self-check closes the gap between the existing Step 3 rules (which agents already follow) and the final output (where gap-only observations still slip through). Expected improvement: pass rate moves from ~69% historical average toward 90%+.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*