### PR TITLE
Auto-improve: previous-recommendations-reviewed

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -15,7 +15,17 @@ Periodic self-assessment of memory quality. Run monthly.
 
 Before starting, find the most recent reflection report in `memory/episodic/reflection-*.md` or `reports/*-memory-reflection.json`. Check which recommendations from that report were acted on since then.
 
-**Action:** Note in this reflection which prior recommendations were implemented, which were ignored, and why. This feeds the `processImprovements` field.
+**Action:** Add a `## Previous Recommendations Review` section to the **markdown report** that explicitly names at least one prior recommendation verbatim or paraphrased, and states its current status as one of: `implemented`, `partially addressed`, or `pending`. Every named recommendation must have a status. Example format:
+
+```markdown
+## Previous Recommendations Review
+- "Split LEARNINGS.md into topical files" (from reflection-2026-05-01) — **pending**: file still over threshold, no split attempted.
+- "Archive REMOVED registry rows" (from reflection-2026-05-01) — **implemented**: rows moved to MEM_REGISTRY_ARCHIVE.md.
+```
+
+If this is the very first reflection with no prior recommendations to review, explicitly state that in the section.
+
+Also feed the results into `processImprovements` — reference any recommendations that remain unacted on.
 
 ### 1. Staleness Check
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** previous-recommendations-reviewed
**Eval date:** 2026-07-05
**Overall score:** 0.9818

### Recent Eval History
- concrete-improvement-proposal: 98%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 86%
- previous-recommendations-reviewed: 81% <-- TARGET
- process-self-critique: 99%
- reduce-log-count: 86%
- semantic-naming-convention: 100%
- summary-md-regenerated: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** previous-recommendations-reviewed
**Files modified:** skills/memory/reflect/skill.md

### What changed

Step 0 of the reflection skill previously told the brain to check prior recommendations and "feed" the results to `processImprovements`, but gave no explicit output requirement for the markdown report itself. The skill only asked to reference recommendations "that went unacted on" — missing ones that were implemented (which also need acknowledgment per the criterion).

The fix adds a concrete `## Previous Recommendations Review` section requirement with an example format, requiring the markdown report to explicitly name at least one prior recommendation (verbatim or paraphrased) and state its status as `implemented`, `partially addressed`, or `pending`.

### Skill Impact

**Skill:** memory/reflect — Memory self-assessment / reflection procedure
**Behavior change:** Reflection reports will now include a dedicated `## Previous Recommendations Review` section in the markdown output that explicitly names prior recommendations and labels each with a status. Previously, this review only implicitly fed into `processImprovements` (and only for unacted items), making it easy to skip or omit from the visible report. The new requirement is concrete, formattefd, and verifiable by the scorer.

### Expected impact

The criterion scorer checks "observations or a dedicated followUp field for explicit references to past recommendations." By requiring a named section in the markdown report with a labeled status for each prior recommendation, the brain's output will consistently satisfy this check — improving the pass rate from the historical 81.3% toward 100%.

### Report insights influence

The observation "The .pending_recs hand-off queue has been recommended and left unimplemented for 4 reflection cycles, so cross-cycle recommendations keep silently resetting" (from reflection in 01KKC6ENR94GF94THS85X20EG5) confirms that prior recommendations were not being tracked across cycles. The fix directly addresses this by requiring explicit named status tracking in every reflection report.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*