### PR TITLE
Auto-improve: verifiable-recommendations

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -115,9 +115,9 @@ Produce both a markdown and JSON report in `reports/` as required by MAINTENANCE
   - "No procedural documentation exists for the weekly-standup workflow, which led to 4 inconsistent invocations across the last 5 standup runs" — gap + observed consequence
   - "episodic/ covers the last 3 months well; the last 2 questions about pre-Q1 incidents required Slack history dives because no episodic entries cover that period" — gap + observed consequence
   - Vague impact language like "this may affect quality" does NOT qualify — the consequence must be specific and already observed.
-- `recommendations`: Specific actions for the next maintenance cycle. If any recommendation would benefit all agents (not just this channel), prefix it with `[base-brain]`. Examples:
-  - "Split semantic/projects.md into per-project files — currently 120 lines"
-  - "[base-brain] Add guidance on deduplicating recurring morning-reflection topics to prevent agents repeating the same question across days"
+- `recommendations`: Specific actions for the next maintenance cycle. If any recommendation would benefit all agents (not just this channel), prefix it with `[base-brain]`. **At least one recommendation MUST include all three of: (1) the concrete change to make, (2) the current problem it addresses, and (3) a verifiable success condition** — a checkable outcome that confirms the recommendation was implemented and effective. Format: `"[change] — [problem] — success: [verifiable condition]"`. Examples:
+  - "Split semantic/projects.md into per-project files — currently 120 lines, causes slow lookups — success: each resulting file under 60 lines at next reflection"
+  - "[base-brain] Add guidance on deduplicating recurring morning-reflection topics — same question appears in consecutive daily logs without resolution — success: next reflection finds no unresolved repeated question across 3 consecutive logs"
 - `selfAssessment`: Use the actual reflection eval criterion IDs: `concrete-improvement-proposal`, `previous-recommendations-reviewed`, `gap-impact-analysis`, `verifiable-recommendations`, `deletion-with-preservation-evidence`.
 - `processImprovements`: Required for reflection reports. Include at least one entry per prefix type (`[self-critique]`, `[proposal]`, `[blocked]`). Reference prior recommendations that went unacted on. Examples:
   - `[self-critique] Reflection is running 45 days late — monthly schedule not enforced by any heartbeat check`


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** verifiable-recommendations
**Eval date:** 2026-07-09
**Overall score:** 0.9778

### Recent Eval History
- concrete-improvement-proposal: 98%
- deletion-with-preservation-evidence: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 95%
- previous-recommendations-reviewed: 69%
- process-self-critique: 100%
- reduce-log-count: 86%
- semantic-naming-convention: 100%
- summary-md-regenerated: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100%
- verifiable-recommendations: 88% <-- TARGET

### What Changed
## Improvement Summary

**Target criterion:** verifiable-recommendations
**Files modified:** skills/memory/reflect/skill.md

### What changed

Updated the `recommendations` field guidance in the reflect skill to explicitly require that at least one recommendation includes all three components needed to pass `verifiable-recommendations`: (1) the concrete change to make, (2) the current problem it addresses, and (3) a verifiable success condition. Updated the examples to model this pattern using the `— success: [condition]` suffix.

Previously, the guidance said "Specific actions for the next maintenance cycle" with examples that included only the action (e.g., "Split semantic/projects.md into per-project files — currently 120 lines"). No success criterion was shown or required, so agents frequently wrote recommendations without one.

### Skill Impact

**Skill:** memory/reflect — Memory self-assessment skill run periodically to check quality, resolve contradictions, and archive stale entries.
**Behavior change:** Reflection reports will now include at least one recommendation with an explicit, checkable success condition, satisfying all three components of the `verifiable-recommendations` eval criterion. The updated examples model the `"[change] — [problem] — success: [verifiable condition]"` format that graders look for.

### Expected impact

Reflection reports should now consistently include at least one verifiable recommendation, improving the `verifiable-recommendations` pass rate from the current 66.7% toward 100%. Report insights also confirm that recommendations with explicit success criteria have higher implementation rates (observed (A)-tagged 6/10 shipped vs (B)-tagged 0/2 shipped), so the change should also improve follow-through on recommendations across cycles.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*