### PR TITLE
Auto-improve: previous-recommendations-reviewed

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -13,9 +13,17 @@ Periodic self-assessment of memory quality. Run monthly.
 
 ### 0. Previous Recommendations Review
 
-Before starting, find the most recent reflection report in `memory/episodic/reflection-*.md` or `reports/*-memory-reflection.json`. Check which recommendations from that report were acted on since then.
+Before starting, find the most recent reflection report in `memory/episodic/reflection-*.md` or `reports/*-memory-reflection.json`. Read its `recommendations` array.
 
-**Action:** Note in this reflection which prior recommendations were implemented, which were ignored, and why. This feeds the `processImprovements` field.
+**If no prior reflection exists:** Add to `processImprovements`: `"[self-critique] No prior reflection found — first reflection run; no prior recommendations to review."` This satisfies the `previous-recommendations-reviewed` criterion.
+
+**If a prior reflection exists:** For each recommendation in that report, determine its status: `implemented`, `partially addressed`, or `pending`. Add **at least one entry** to `processImprovements` that names the specific recommendation text and its status. Required format:
+
+```
+[self-critique] Prior rec: "<recommendation text>" — status: implemented/partially addressed/pending. <one-sentence reason>.
+```
+
+All prior-recommendation review entries MUST appear in `processImprovements`. The `previous-recommendations-reviewed` eval criterion passes only when the report explicitly names at least one prior recommendation and states its status. A generic "reviewed prior recommendations" without naming one fails the criterion.
 
 ### 1. Staleness Check
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** previous-recommendations-reviewed
**Eval date:** 2026-07-11
**Overall score:** 0.9606

### Recent Eval History
- concrete-improvement-proposal: 100%
- evidence-backed-decisions: 100%
- gap-impact-analysis: 95%
- previous-recommendations-reviewed: 86% <-- TARGET
- process-self-critique: 100%
- reduce-log-count: 100%
- semantic-naming-convention: 100%
- summary-md-regenerated: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100%

### What Changed
# Improvement Summary

**Target criterion:** `previous-recommendations-reviewed`
**Files modified:** `skills/memory/reflect/skill.md`

### What changed

Step 0 ("Previous Recommendations Review") of the reflect skill was tightened in two ways:

1. **No-prior-reflection fallback** — the old guidance had no handling for when no prior reflection report exists. The brain would silently skip Step 0 or produce a vague note, causing criterion failure. Now it specifies an exact `processImprovements` entry to write in that case, which the evaluator can verify.

2. **Explicit output format required** — the old guidance said to "note which recommendations were implemented, ignored, and why" and that it "feeds the `processImprovements` field," but gave no required format. Evaluators check for an explicit named recommendation + status in the report. The new guidance prescribes a required format (`[self-critique] Prior rec: "<text>" — status: implemented/partially addressed/pending.`) and adds a clear reminder that a generic "reviewed prior recommendations" phrase fails the criterion.

### Skill Impact

**Skill:** `memory/reflect` — Memory self-assessment skill run during maintenance.

**Behavior change:** Step 0 now produces a verifiable, structured entry in `processImprovements` for every reflection run — either naming a specific prior recommendation with its status, or explicitly stating this is a first-run with no prior recommendations. This removes the ambiguity that allowed agents to produce vague Step 0 output that technically acknowledged the step but did not satisfy the criterion's "explicitly references" bar.

### Expected impact

Reports that previously passed Step 0 implicitly (or skipped it on first runs) will now consistently produce criterion-verifiable output. Pass rate should improve from the 0.857 historical average toward 1.0.

### Report insights influence

No specific recommendation from `report-insights.md` directly addressed this criterion. The change was driven by the criterion definition gap: the skill lacked a prescribed output format and no-prior-reflection handling.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*