### PR TITLE
slack: extract buildSendPayload() + unit-lock branch logic (tv.ai#228 #4)

### DIFF
--- a/mcp/__tests__/slack-payload.test.mjs
+++ b/mcp/__tests__/slack-payload.test.mjs
@@ -1,0 +1,87 @@
+// Unit tests for buildSendPayload() — the pure send_message branch logic
+// (tv.ai#228 follow-up #4). Locks the three-way decision regressibly:
+//   (a) auto-convert  — pipe-table in `text` AND no agent blocks
+//   (b) section-prepend — `text` + agent blocks (or modals)
+//   (c) verbatim passthrough — plain `text`, no blocks
+// slack.mjs auto-starts a stdio server on import, so we load just the pure
+// prelude (everything before the transport section) and export-by-eval the
+// helper. No network, no Slack. Run: node mcp/__tests__/slack-payload.test.mjs
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'slack.mjs'), 'utf8')
+const prelude = src.split('// --- stdio transport ---')[0]
+const exports = '\nexport { buildSendPayload }\n'
+const mod = await import('data:text/javascript,' + encodeURIComponent(prelude + exports))
+const { buildSendPayload } = mod
+
+let pass = 0, fail = 0
+const ok = (n, c) => { if (c) { pass++; console.log('  ✓', n) } else { fail++; console.log('  ✗ FAIL', n) } }
+
+const TABLE = '| úkol | stav |\n|---|---|\n| deploy | ✅ |'
+
+// (a) auto-convert branch: pipe-table in text, no agent blocks
+{
+  const r = buildSendPayload({ text: `Hotovo:\n\n${TABLE}` })
+  ok('a transformed echo present', r.transformed?.reason === 'pipe_table_in_text')
+  ok('a exactly one markdown block', r.blocks.filter(b => b.type === 'markdown').length === 1)
+  ok('a effectiveText = native fallback (no pipes)', !r.effectiveText.includes('|'))
+  // raw tableWarning still returned — the caller suppresses it because transformed is set
+  ok('a raw tableWarning returned for caller to suppress', !!r.tableWarning)
+  ok('a agentSuppliedBlocks false', r.agentSuppliedBlocks === false)
+}
+
+// (b) opt-out passthrough: agent supplied its own blocks + a table in text
+{
+  const own = [{ type: 'section', text: { type: 'mrkdwn', text: 'mine' } }]
+  const r = buildSendPayload({ text: `Hotovo:\n\n${TABLE}`, blocks: own })
+  ok('b NOT converted (opt-out)', r.transformed === null)
+  ok('b tableWarning kept (table left in text)', !!r.tableWarning)
+  ok('b effectiveText unchanged verbatim', r.effectiveText === `Hotovo:\n\n${TABLE}`)
+  // text is section-prepended ahead of the agent's own blocks
+  ok('b sections prepended before own blocks', r.blocks[r.blocks.length - 1] === own[0] && r.blocks[0].type === 'section')
+  ok('b agentSuppliedBlocks true', r.agentSuppliedBlocks === true)
+}
+
+// (b') section-prepend with blocks but no table in text
+{
+  const own = [{ type: 'divider' }]
+  const r = buildSendPayload({ text: 'plain prose', blocks: own })
+  ok("b' no transform, no table warning", r.transformed === null && !r.tableWarning)
+  ok("b' prose section prepended, divider kept last", r.blocks[0].type === 'section' && r.blocks[r.blocks.length - 1].type === 'divider')
+}
+
+// (b'') modals present, no agent blocks, no table → text still section-prepended
+{
+  const r = buildSendPayload({ text: 'open the form' }, { hasModals: true })
+  ok("b'' modal path prepends text sections", r.blocks.length > 0 && r.blocks.every(b => b.type === 'section'))
+  ok("b'' no transform", r.transformed === null)
+}
+
+// (c) verbatim passthrough: plain text, no blocks, no modals → NO blocks added
+{
+  const r = buildSendPayload({ text: 'just a normal message' })
+  ok('c no blocks synthesized', r.blocks.length === 0)
+  ok('c effectiveText verbatim', r.effectiveText === 'just a normal message')
+  ok('c no transform, no table warning', r.transformed === null && !r.tableWarning)
+}
+
+// (d) edge: empty / whitespace-only text must not throw or convert
+{
+  const r1 = buildSendPayload({ text: '   ' })
+  const r2 = buildSendPayload({})
+  ok('d whitespace text → no blocks, no transform', r1.blocks.length === 0 && r1.transformed === null)
+  ok('d missing text → no crash, no blocks', r2.blocks.length === 0 && r2.transformed === null)
+}
+
+// (e) fleet-safety invariant: agent that already sends blocks+text is never auto-converted,
+// even when the text contains a table (the exact regression #206 guarded against)
+{
+  const own = [{ type: 'markdown', text: TABLE }]
+  const r = buildSendPayload({ text: TABLE, blocks: own })
+  ok('e agent blocks+table text → passthrough (no double render path)', r.transformed === null)
+}
+
+console.log(`\n${pass} passed, ${fail} failed`)
+if (fail) process.exit(1)

--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -294,6 +294,38 @@ function convertPipeTablesToBlocks(text) {
   }
 }
 
+// Pure payload builder for send_message: decides final blocks / effective text /
+// transform echo BEFORE any network I/O, so the three-way branch (auto-convert
+// vs section-prepend vs verbatim passthrough) is unit-testable without Slack.
+// tv.ai#228 follow-up #4. `hasModals` is passed in rather than derived here
+// because it depends on runtime API_URL/TOKEN presence. Returns the raw
+// `tableWarning` (the caller decides suppression: convert branch handled the
+// table, opt-out/passthrough keeps the #224 warning). No behavior change vs the
+// prior inline logic — this is an extraction to lock the branches regressibly.
+function buildSendPayload(args, { hasModals = false } = {}) {
+  const agentBlocks = args.blocks ? [...args.blocks] : []
+  const agentSuppliedBlocks = agentBlocks.length > 0
+  const tableWarning = computePipeTableWarning(args.text)
+
+  let blocks = agentBlocks
+  let effectiveText = args.text
+  let transformed = null
+
+  const converted =
+    args.text?.trim() && tableWarning && !agentSuppliedBlocks
+      ? convertPipeTablesToBlocks(args.text)
+      : null
+  if (converted) {
+    blocks = converted.blocks
+    effectiveText = converted.fallbackText
+    transformed = converted.transformed
+  } else if (args.text?.trim() && (agentSuppliedBlocks || hasModals)) {
+    blocks = [...textToSections(args.text), ...agentBlocks]
+  }
+
+  return { blocks, effectiveText, transformed, tableWarning, agentSuppliedBlocks }
+}
+
 // Resolve a Slack user_id to a friendly display name. Caches per-process for
 // the session lifetime since display names rarely change mid-conversation.
 const _userInfoCache = new Map()
@@ -538,30 +570,18 @@ async function handleTool(name, args) {
       const thread_ts = args.thread_ts === undefined ? DEFAULT_THREAD_TS : args.thread_ts
       if (!channel) throw new Error('channel required')
 
-      let blocks = args.blocks ? [...args.blocks] : []
       const hasModals = args.modals?.length && API_URL && TOKEN
-      const agentSuppliedBlocks = blocks.length > 0
 
       // tv.ai#228 auto-convert: if `text` carries a pipe-table AND the agent
       // did NOT supply its own blocks, move the table(s) into `markdown` block(s)
       // and use a native (non-prepended) plain-text fallback. Deterministic,
       // opt-out by supplying blocks, echoed to the LLM via `transformed`.
       // Everything else keeps the exact prior behavior (fleet-safety: agents
-      // that already send blocks+text are untouched).
-      const tableWarning = computePipeTableWarning(args.text)
-      let transformed = null
-      let effectiveText = args.text
-      const converted =
-        args.text?.trim() && tableWarning && !agentSuppliedBlocks
-          ? convertPipeTablesToBlocks(args.text)
-          : null
-      if (converted) {
-        blocks = converted.blocks
-        effectiveText = converted.fallbackText
-        transformed = converted.transformed
-      } else if (args.text?.trim() && (blocks.length || hasModals)) {
-        blocks = [...textToSections(args.text), ...blocks]
-      }
+      // that already send blocks+text are untouched). Branch logic lives in the
+      // pure buildSendPayload() (unit-tested, no I/O).
+      const { blocks, effectiveText, transformed, tableWarning } = buildSendPayload(args, {
+        hasModals: Boolean(hasModals),
+      })
 
       // Send the message first (without modal buttons if top-level)
       // We need the message ts for thread context when there's no thread_ts


### PR DESCRIPTION
## What

tv.ai#228 follow-up **#4** — extract `buildSendPayload(args, {hasModals})` out of the `send_message` handler and lock its branch logic with unit tests.

The pure convert helpers (`convertPipeTablesToBlocks`, `computePipeTableWarning`, …) were already unit-tested; the **handler branch that chooses between them** was only verified by inspection. This extracts that decision into a pure function and tests it directly.

## Branches locked

`buildSendPayload` returns `{ blocks, effectiveText, transformed, tableWarning, agentSuppliedBlocks }` for the three cases:
- **(a) auto-convert** — pipe-table in `text` AND no agent blocks → `transformed` set, table → `markdown` block, native fallback text.
- **(b) section-prepend** — `text` + agent blocks (or modals) → `text` prepended as section(s) ahead of agent blocks.
- **(c) verbatim passthrough** — plain `text`, no blocks → no synthesized blocks, text unchanged.

## No behavior change

The handler now destructures the same values it previously computed inline. Warning-suppression is unchanged — the caller still keys off `transformed` (raw `tableWarning` is returned for the caller to suppress). Verified:
- `mcp/__tests__/slack-payload.test.mjs` — **20 assertions**, all pass (incl. the #206 fleet-safety invariant: agent-supplied blocks + table-in-text is never auto-converted → no double-render).
- `mcp/__tests__/slack-convert.test.mjs` — existing **18** still pass.
- `node --check mcp/slack.mjs` clean.

## Tier

Tier-1 (behavior-preserving refactor + test-only additions on the fleet Slack path). Requesting DevGuru sign-off before merge per convention.

Tracker: teamvibeai/teamvibe.ai#228 (core shipped in #206).

🤖 Generated with [Claude Code](https://claude.com/claude-code)