### PR TITLE
Auto-improve: deletion-with-preservation-evidence

### DIFF
--- a/skills/memory/reflect/skill.md
+++ b/skills/memory/reflect/skill.md
@@ -35,6 +35,8 @@ Scan all memory files for information that may be outdated:
 
 **Action:** Mark stale entries with `[STALE?]` or archive to `memory/episodic/archive/`
 
+**Deletion logging (required at point of deletion):** For every file you delete in this step, immediately add a `decisions` entry before removing the file: `"Deleted [path] — content merged into [specific/destination/file.md]"` OR `"Deleted [path] — content fully superseded by [specific/existing/file.md]"`. Generic phrases like "archived" or "no data loss" without naming the specific file DO NOT qualify. Log first, delete second — this evidence is required for `deletion-with-preservation-evidence`.
+
 ### 2. Contradiction Check
 
 Look for conflicting information across memory files:
@@ -81,6 +83,8 @@ Review memory files for bloat:
 - MEMORY.md should be under 100 lines
 
 **Action:** Split, prune, or archive as needed.
+
+**Deletion logging (required at point of deletion):** For every file deleted or replaced during this step, immediately add a `decisions` entry: `"Deleted [path] — split into [file-a.md] and [file-b.md]"` OR `"Deleted [path] — content merged into [specific/file.md]"` OR `"Deleted [path] — content redundant with [specific/existing/file.md]"`. Log the specific destination(s) before deleting. This is required evidence for `deletion-with-preservation-evidence` — generic "pruned" or "archived" entries without named files fail the criterion.
 
 ## Output
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** deletion-with-preservation-evidence
**Eval date:** 2026-07-16
**Overall score:** 0.9226

### Recent Eval History
- concrete-improvement-proposal: 100%
- deletion-with-preservation-evidence: 96% <-- TARGET
- evidence-backed-decisions: 100%
- gap-impact-analysis: 97%
- previous-recommendations-reviewed: 100%
- process-self-critique: 100%
- reduce-log-count: 100%
- semantic-naming-convention: 100%
- summary-md-regenerated: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** deletion-with-preservation-evidence
**Files modified:** skills/memory/reflect/skill.md

### What changed

Added inline "Deletion logging" requirements directly in Step 1 (Staleness Check) and Step 4 (Size Check) of the reflection skill. Each deletion-prone step now instructs the agent to record a `decisions` entry with the specific destination file *before* removing the file, and explicitly states that generic phrases like "archived" or "no data loss" without naming a specific file do not qualify.

The skill already had a pre-write deletion accounting check (before finalizing the report), but that retrospective check can fail if the agent forgot which files were deleted and what happened to their content. The new inline logging requirement addresses the root failure mode: documentation must happen at the point of deletion, not as an afterthought.

### Skill Impact

**Skill:** memory/reflect — Memory self-assessment skill run during maintenance to check memory quality, resolve contradictions, and archive stale entries.

**Behavior change:** Steps 1 and 4 now require the agent to log each file deletion with its specific preservation destination immediately, before deleting the file. This creates a per-deletion audit trail that the existing pre-write check (line ~134) then verifies against, making the two checks work together: inline logging catches the evidence at creation time; the pre-write check confirms all deletions are covered before the report is finalized.

### Expected impact

The `deletion-with-preservation-evidence` criterion currently passes 95.8% of the time historically. The failure mode is reflection reports that delete files but document preservation with generic phrases ("archived", "no data loss") rather than naming specific destination files. By requiring named-destination logging at the point of deletion — not just before writing the report — the criterion should pass consistently.

### Report insights influence

No specific report-insights.md entry directly referenced `deletion-with-preservation-evidence`. The registry-archive recommendations (e.g., "apply the registry-archive template (preservation evidence + dual pointer)") confirm that preservation evidence for deletions is an observed real-world gap, supporting the targeted improvement to the reflection skill's deletion handling.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*