### PR TITLE
feat(memory): archive REMOVED registry rows to keep MEM_REGISTRY.md bounded

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -414,6 +414,28 @@ If the Memory Metrics table (Step 9b) shows `CLAUDE.md` exceeding 10000 bytes, p
 
 This ensures steady progress toward the threshold while allowing time to detect regressions between cycles.
 
+#### 9d. MEM_REGISTRY.md REMOVED-Row Archival
+
+`MEM_REGISTRY.md` is append-only for audit reasons — REMOVED rows are never deleted (Step 1c), so the registry grows unbounded. This step relocates **dead REMOVED audit rows** to `memory/MEM_REGISTRY_ARCHIVE.md`, leaving a single navigable pointer stub in the live registry. ACTIVE / OBSOLETE rows and all prose stay untouched.
+
+> **Scope — mechanical only.** This automates relocation of *dead* data (rows already marked REMOVED via the MEM lifecycle). It does **not** touch ACTIVE/OBSOLETE rows or inline policy prose (e.g. HOLD-rule sections) — relocating live content is a semantic judgment that stays with reflection, not this automated step. On registries whose bulk is live prose, the byte target may need a complementary manual prose move; that is out of scope here.
+
+If the Memory Metrics table (Step 9b) shows `MEM_REGISTRY.md` exceeding 5000 bytes, run the deterministic archival script:
+
+```bash
+npx tsx "$CLAUDE_CONFIG_DIR/skills/memory/scripts/mem-registry-archive.ts"
+```
+
+The script is **idempotent** (a second consecutive run is a byte-identical no-op) and performs its own **count-verify** before writing — it aborts (exit 1) without writing if any REMOVED row would be dropped (round-trip identity) or if the live REMOVED count would not reach 0. Do not hand-edit `MEM_REGISTRY.md` to remove REMOVED rows; always use the script.
+
+1. **Run it** and read the printed summary (relocated keys, `removedFromLive`, `newlyArchived`, `alreadyInArchive`, `liveRemovedAfter`, size delta, verify checks).
+2. **On non-zero exit**, treat it as an integrity alarm: do NOT commit a partial state, and record the failure in the report. Investigate before retrying.
+3. **Log it** in the markdown report under `## MEM_REGISTRY Archival`: relocated keys, size delta, and the three verify checks (`round-trip`, `count`, `live REMOVED == 0`).
+4. **Report tracking:** add `memory/MEM_REGISTRY.md` and `memory/MEM_REGISTRY_ARCHIVE.md` to `filesChanged` when the script relocated any rows (skip both when it was a no-op).
+5. If `MEM_REGISTRY.md` is under 5000 bytes, or the script reports a no-op, skip logging this step.
+
+The stub the script leaves is a pointer — `> 📦 N REMOVED audit entries archived to [MEM_REGISTRY_ARCHIVE.md](...) — Keys: ...` — so the audit trail stays navigable from the live registry. The key list in the stub also keeps the `mem-write.ts` next-key counter correct (it additionally scans the archive as defense-in-depth).
+
 ### 10. Assess Daily Log Compliance
 
 Before self-critique, run observable checks on the daily log scratchpad and record the outcome in both reports.

--- a/skills/memory/scripts/lib/mem-registry-archive-core.ts
+++ b/skills/memory/scripts/lib/mem-registry-archive-core.ts
@@ -1,0 +1,227 @@
+/**
+ * Pure relocation logic for MEM_REGISTRY.md REMOVED-row archival.
+ *
+ * Why a step exists: `MEM_REGISTRY.md` is append-only for audit reasons —
+ * REMOVED rows are never deleted, so the registry grows unbounded (11 REMOVED
+ * rows already push it 4× over its 5000-byte threshold with no in-channel
+ * reduction path). This module relocates dead REMOVED audit rows to
+ * `MEM_REGISTRY_ARCHIVE.md`, leaving a single navigable stub pointer in the
+ * live registry. ACTIVE / OBSOLETE rows and all prose stay untouched.
+ *
+ * Reference: poller-brain#175 (LEARNINGS gate — kept manual, gate not built);
+ * this covers only the mechanical dead-data relocation DevGuru ACK'd.
+ *
+ * Design constraints (DevGuru review conditions):
+ *   1. Idempotent — consolidate can run twice in a row (gap-day /
+ *      reflection-only sequences). A second run must be a byte-identical
+ *      no-op: REMOVED rows are gone, the regenerated stub is not a data row,
+ *      so nothing is re-matched or duplicated.
+ *   2. Count-verifiable — every REMOVED row leaving the live table must land
+ *      in the archive (round-trip identity, MEM-6), and the live REMOVED count
+ *      must be 0 afterward. Callers assert on the returned stats and FAIL LOUD.
+ *   3. Stub is a pointer (count + link + key list), never a bare deletion.
+ *
+ * This module is intentionally fs-free so the invariants can be unit-tested
+ * against string fixtures without touching a real brain's memory/.
+ */
+
+export const ARCHIVE_HEADER = `# MEM Registry — Archive
+
+REMOVED audit rows relocated from \`MEM_REGISTRY.md\` to keep the live registry
+under threshold. Appended by \`skills/memory/scripts/mem-registry-archive.ts\`
+during consolidation — do not hand-edit. Full lifecycle history lives here;
+the live registry keeps only ACTIVE / OBSOLETE rows plus a pointer stub.
+
+| Key | Status | Created | Obsoleted | Description |
+|-----|--------|---------|-----------|-------------|
+`;
+
+/** Matches the pointer stub so it can be regenerated (never appended twice). */
+export const STUB_RE = /^> 📦 \d+ REMOVED /;
+
+const DATA_ROW_RE = /^\|\s*(MEM-\d+)\s*\|/;
+
+export interface ArchiveStats {
+  /** REMOVED data rows found in the live registry before the run. */
+  removedFromLive: number;
+  /** Rows newly appended to the archive this run (were not already there). */
+  newlyArchived: number;
+  /** REMOVED rows already present in the archive (idempotent re-run / partial). */
+  alreadyInArchive: number;
+  /** Total distinct MEM keys in the archive after the run. */
+  totalArchived: number;
+  /** REMOVED data rows still in the live registry after the run (must be 0). */
+  liveRemovedAfter: number;
+  /** Keys that failed round-trip (removed from live but absent from archive). */
+  missing: string[];
+  /** Keys relocated this run, sorted. */
+  archivedKeys: string[];
+}
+
+export interface ArchiveResult {
+  registry: string;
+  archive: string;
+  stats: ArchiveStats;
+}
+
+function dataKey(line: string): string | null {
+  const m = line.match(DATA_ROW_RE);
+  return m ? m[1] : null;
+}
+
+function statusOf(line: string): string {
+  // cells: ["", " MEM-N ", " STATUS ", ...] — index 2 is the status column.
+  const cells = line.split("|");
+  return cells.length > 2 ? cells[2].trim() : "";
+}
+
+function keysIn(content: string): Set<string> {
+  const keys = new Set<string>();
+  for (const line of content.split("\n")) {
+    const k = dataKey(line);
+    if (k) keys.add(k);
+  }
+  return keys;
+}
+
+function sortKeys(keys: Iterable<string>): string[] {
+  return [...keys].sort(
+    (a, b) => parseInt(a.slice(4), 10) - parseInt(b.slice(4), 10)
+  );
+}
+
+/**
+ * Relocate REMOVED rows from a live registry into an archive.
+ *
+ * @param registry current MEM_REGISTRY.md content
+ * @param archive  current MEM_REGISTRY_ARCHIVE.md content ("" if it doesn't exist)
+ * @returns new registry + archive content and machine-checkable stats
+ */
+export function archiveRemovedRows(
+  registry: string,
+  archive: string
+): ArchiveResult {
+  const removedRows: { key: string; line: string }[] = [];
+  const kept: string[] = [];
+
+  for (const line of registry.split("\n")) {
+    const key = dataKey(line);
+    if (key && statusOf(line) === "REMOVED") {
+      removedRows.push({ key, line });
+    } else if (STUB_RE.test(line)) {
+      // Drop any prior stub; it is regenerated below from the archive total.
+      continue;
+    } else {
+      kept.push(line);
+    }
+  }
+
+  // Seed / extend the archive, deduping by key so re-runs never duplicate.
+  const archiveBody = archive.trim().length ? archive : ARCHIVE_HEADER;
+  const archiveLines = archiveBody.replace(/\n+$/, "").split("\n");
+  const archiveKeys = keysIn(archiveBody);
+
+  let newlyArchived = 0;
+  let alreadyInArchive = 0;
+  for (const { key, line } of removedRows) {
+    if (archiveKeys.has(key)) {
+      alreadyInArchive++;
+    } else {
+      archiveLines.push(line);
+      archiveKeys.add(key);
+      newlyArchived++;
+    }
+  }
+  const newArchive = archiveLines.join("\n") + "\n";
+
+  // Round-trip guard: every relocated key must exist in the archive now.
+  const archiveKeysAfter = keysIn(newArchive);
+  const missing = removedRows
+    .map((r) => r.key)
+    .filter((k) => !archiveKeysAfter.has(k));
+
+  // Regenerate the pointer stub from the archive total, placed right after the
+  // last live data row so re-runs land it in the identical spot (idempotent).
+  const archivedKeys = sortKeys(archiveKeysAfter);
+  let newRegistry: string;
+  if (archivedKeys.length === 0) {
+    newRegistry = kept.join("\n");
+  } else {
+    const stub =
+      `> 📦 ${archivedKeys.length} REMOVED audit ${archivedKeys.length === 1 ? "entry" : "entries"} ` +
+      `archived to [MEM_REGISTRY_ARCHIVE.md](MEM_REGISTRY_ARCHIVE.md) — ` +
+      `Keys: ${archivedKeys.join(", ")}`;
+    let lastDataIdx = -1;
+    for (let i = 0; i < kept.length; i++) {
+      if (dataKey(kept[i])) lastDataIdx = i;
+    }
+    if (lastDataIdx === -1) {
+      // No data rows left (registry was all-REMOVED) — append stub at end.
+      newRegistry = [...kept, stub].join("\n");
+    } else {
+      newRegistry = [
+        ...kept.slice(0, lastDataIdx + 1),
+        stub,
+        ...kept.slice(lastDataIdx + 1),
+      ].join("\n");
+    }
+  }
+
+  const liveRemovedAfter = newRegistry
+    .split("\n")
+    .filter((l) => dataKey(l) && statusOf(l) === "REMOVED").length;
+
+  return {
+    registry: newRegistry,
+    archive: newArchive,
+    stats: {
+      removedFromLive: removedRows.length,
+      newlyArchived,
+      alreadyInArchive,
+      totalArchived: archiveKeysAfter.size,
+      liveRemovedAfter,
+      missing,
+      archivedKeys: sortKeys(removedRows.map((r) => r.key)),
+    },
+  };
+}
+
+/**
+ * Machine count-verify. Throws with an actionable message on any invariant
+ * break so the CLI / consolidate step fails loud rather than silently
+ * dropping a line. Returns the list of assertions that passed.
+ */
+export function verifyStats(stats: ArchiveStats): string[] {
+  const checks: string[] = [];
+
+  if (stats.missing.length > 0) {
+    throw new Error(
+      `Round-trip failure: ${stats.missing.length} REMOVED key(s) left the live ` +
+        `registry but are absent from the archive: ${stats.missing.join(", ")}. ` +
+        `Aborting — no write performed.`
+    );
+  }
+  checks.push(`round-trip: all ${stats.removedFromLive} relocated keys present in archive ✅`);
+
+  // "živé REMOVED odebrané == archive přidané" — in the normal path every
+  // relocated row is newly archived; a re-run may find some already there.
+  if (stats.newlyArchived + stats.alreadyInArchive !== stats.removedFromLive) {
+    throw new Error(
+      `Count mismatch: removedFromLive=${stats.removedFromLive} but ` +
+        `newlyArchived(${stats.newlyArchived}) + alreadyInArchive(${stats.alreadyInArchive}) ` +
+        `= ${stats.newlyArchived + stats.alreadyInArchive}.`
+    );
+  }
+  checks.push(
+    `count: removedFromLive(${stats.removedFromLive}) == newlyArchived(${stats.newlyArchived}) + alreadyInArchive(${stats.alreadyInArchive}) ✅`
+  );
+
+  if (stats.liveRemovedAfter !== 0) {
+    throw new Error(
+      `Live registry still has ${stats.liveRemovedAfter} REMOVED row(s) after archival — expected 0.`
+    );
+  }
+  checks.push(`live REMOVED count after run == 0 ✅`);
+
+  return checks;
+}

--- a/skills/memory/scripts/mem-registry-archive.test.ts
+++ b/skills/memory/scripts/mem-registry-archive.test.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env npx tsx
+/**
+ * Fixture-based self-test for the MEM_REGISTRY archival logic.
+ *
+ * Runs the DevGuru count-verify conditions against string fixtures (no fs):
+ *   - round-trip identity: every REMOVED row relocated is present in archive
+ *   - count: removedFromLive == newlyArchived + alreadyInArchive
+ *   - live REMOVED count after run == 0
+ *   - idempotence: a second run is a byte-identical no-op
+ *   - prose containing the word "REMOVED" is never touched
+ *   - ACTIVE / OBSOLETE rows and header prose are preserved
+ *
+ * Run: npx tsx skills/memory/scripts/mem-registry-archive.test.ts
+ * Exits non-zero on the first failed assertion.
+ */
+
+import {
+  archiveRemovedRows,
+  verifyStats,
+} from "./lib/mem-registry-archive-core.js";
+
+let passed = 0;
+function assert(cond: boolean, msg: string): void {
+  if (!cond) {
+    console.error(`❌ FAIL: ${msg}`);
+    process.exit(1);
+  }
+  passed++;
+}
+
+// A fixture that mirrors the real registry shape: prose sections that mention
+// "REMOVED" in text (must NOT be relocated) + a 5-column table with a mix of
+// ACTIVE / OBSOLETE / REMOVED rows.
+const REGISTRY = `# MEM Registry
+
+## HOLD lifecycle rule
+
+- **REMOVE** → set status REMOVED with brief justification (this prose line mentions REMOVED and must stay).
+
+| Key | Status | Created | Obsoleted | Description |
+|-----|--------|---------|-----------|-------------|
+| MEM-1 | ACTIVE | 2026-04-29 | — | keep me active |
+| MEM-2 | REMOVED | 2026-04-29 | 2026-05-25 | superseded by MEM-7 |
+| MEM-3 | REMOVED | 2026-04-30 | 2026-05-25 | superseded by MEM-10 |
+| MEM-4 | OBSOLETE | 2026-05-01 | 2026-05-25 | pending removal next cycle |
+| MEM-5 | REMOVED | 2026-05-04 | 2026-05-25 | moved to semantic/ |
+`;
+
+// --- Run 1: fresh archive ---------------------------------------------------
+const r1 = archiveRemovedRows(REGISTRY, "");
+const c1 = verifyStats(r1.stats);
+
+assert(r1.stats.removedFromLive === 3, "should find 3 REMOVED rows");
+assert(r1.stats.newlyArchived === 3, "should newly archive 3 rows");
+assert(r1.stats.alreadyInArchive === 0, "nothing pre-archived on fresh run");
+assert(r1.stats.liveRemovedAfter === 0, "no REMOVED rows left in live registry");
+assert(r1.stats.missing.length === 0, "no round-trip misses");
+assert(
+  r1.stats.archivedKeys.join(",") === "MEM-2,MEM-3,MEM-5",
+  "relocated the correct keys"
+);
+assert(c1.length === 3, "all 3 verify checks passed");
+
+// Live registry keeps ACTIVE + OBSOLETE, drops REMOVED, prose intact.
+assert(/\| MEM-1 \| ACTIVE/.test(r1.registry), "ACTIVE row kept");
+assert(/\| MEM-4 \| OBSOLETE/.test(r1.registry), "OBSOLETE row kept");
+assert(!/\| MEM-2 \| REMOVED/.test(r1.registry), "REMOVED MEM-2 removed from live");
+assert(!/\| MEM-3 \| REMOVED/.test(r1.registry), "REMOVED MEM-3 removed from live");
+assert(!/\| MEM-5 \| REMOVED/.test(r1.registry), "REMOVED MEM-5 removed from live");
+assert(
+  /- \*\*REMOVE\*\* → set status REMOVED/.test(r1.registry),
+  "prose line mentioning REMOVED is preserved"
+);
+
+// Stub is a pointer with count + link + keys.
+assert(
+  /> 📦 3 REMOVED audit entries archived to \[MEM_REGISTRY_ARCHIVE\.md\]\(MEM_REGISTRY_ARCHIVE\.md\) — Keys: MEM-2, MEM-3, MEM-5/.test(
+    r1.registry
+  ),
+  "stub pointer present with count, link, and key list"
+);
+assert((r1.registry.match(/📦/g) || []).length === 1, "exactly one stub line");
+
+// Archive holds every relocated row verbatim.
+for (const key of ["MEM-2", "MEM-3", "MEM-5"]) {
+  assert(
+    new RegExp(`\\| ${key} \\| REMOVED`).test(r1.archive),
+    `${key} present in archive`
+  );
+}
+
+// --- Run 2: idempotence — feed run-1 output back in -------------------------
+const r2 = archiveRemovedRows(r1.registry, r1.archive);
+verifyStats(r2.stats);
+assert(r2.stats.removedFromLive === 0, "run 2 finds no REMOVED rows");
+assert(r2.stats.newlyArchived === 0, "run 2 archives nothing new");
+assert(
+  r2.registry === r1.registry,
+  "run 2 registry is byte-identical (idempotent)"
+);
+assert(r2.archive === r1.archive, "run 2 archive is byte-identical (idempotent)");
+
+// --- Run 3: a NEW removal on top of an existing archive ---------------------
+const registryWithNewRemoval = r1.registry.replace(
+  "| MEM-4 | OBSOLETE | 2026-05-01 | 2026-05-25 | pending removal next cycle |",
+  "| MEM-4 | REMOVED | 2026-05-01 | 2026-06-30 | removed this cycle |"
+);
+const r3 = archiveRemovedRows(registryWithNewRemoval, r1.archive);
+verifyStats(r3.stats);
+assert(r3.stats.removedFromLive === 1, "run 3 finds the 1 new REMOVED row");
+assert(r3.stats.newlyArchived === 1, "run 3 archives 1 new row");
+assert(r3.stats.totalArchived === 4, "archive now holds 4 keys");
+assert(r3.stats.liveRemovedAfter === 0, "no REMOVED rows left after run 3");
+assert(
+  /> 📦 4 REMOVED audit entries .* Keys: MEM-2, MEM-3, MEM-4, MEM-5/.test(
+    r3.registry
+  ),
+  "stub count + keys updated after new removal"
+);
+
+// --- Run 4: partial re-run — same removed row already in archive ------------
+// Simulates a crash-between-writes: live still has a REMOVED row that already
+// made it to the archive. Must not duplicate, must still clear it from live.
+const r4 = archiveRemovedRows(registryWithNewRemoval, r3.archive);
+verifyStats(r4.stats);
+assert(r4.stats.alreadyInArchive === 1, "already-archived row detected");
+assert(r4.stats.newlyArchived === 0, "no duplicate append");
+assert(r4.stats.liveRemovedAfter === 0, "live row still cleared");
+assert(
+  (r4.archive.match(/\| MEM-4 \| REMOVED/g) || []).length === 1,
+  "MEM-4 not duplicated in archive"
+);
+
+console.log(`✅ all ${passed} assertions passed`);

--- a/skills/memory/scripts/mem-registry-archive.ts
+++ b/skills/memory/scripts/mem-registry-archive.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env npx tsx
+/**
+ * Relocate REMOVED audit rows from memory/MEM_REGISTRY.md into
+ * memory/MEM_REGISTRY_ARCHIVE.md, leaving a single pointer stub in the live
+ * registry. Keeps the live registry under threshold without deleting audit
+ * history. See lib/mem-registry-archive-core.ts for the invariants.
+ *
+ * Invoked by the consolidate skill (Step 9d) when MEM_REGISTRY.md exceeds its
+ * threshold. Safe to run anytime: a no-op when there are no REMOVED rows.
+ *
+ * Idempotent: a second consecutive run is a byte-identical no-op.
+ * Count-verified: aborts (exit 1) on any invariant break — no silent drop.
+ *
+ * Usage:
+ *   npx tsx mem-registry-archive.ts          # relocate + verify + write
+ *   npx tsx mem-registry-archive.ts --check  # dry-run: report + verify, no write
+ */
+
+import * as fs from "fs";
+import { brainPath } from "./lib/brain-root.js";
+import {
+  archiveRemovedRows,
+  verifyStats,
+} from "./lib/mem-registry-archive-core.js";
+
+const REGISTRY_PATH = brainPath("memory/MEM_REGISTRY.md");
+const ARCHIVE_PATH = brainPath("memory/MEM_REGISTRY_ARCHIVE.md");
+
+function main(): void {
+  const dryRun = process.argv.includes("--check");
+
+  if (!fs.existsSync(REGISTRY_PATH)) {
+    console.log(`No MEM_REGISTRY.md at ${REGISTRY_PATH} — nothing to archive.`);
+    return;
+  }
+
+  const registryBefore = fs.readFileSync(REGISTRY_PATH, "utf-8");
+  const archiveBefore = fs.existsSync(ARCHIVE_PATH)
+    ? fs.readFileSync(ARCHIVE_PATH, "utf-8")
+    : "";
+
+  const { registry, archive, stats } = archiveRemovedRows(
+    registryBefore,
+    archiveBefore
+  );
+
+  // Machine count-verify BEFORE writing — throws (→ exit 1) on any violation.
+  const checks = verifyStats(stats);
+
+  if (stats.removedFromLive === 0) {
+    console.log(
+      `No REMOVED rows in live registry — already archived (${stats.totalArchived} in archive). No-op.`
+    );
+    return;
+  }
+
+  const registryChanged = registry !== registryBefore;
+  const archiveChanged = archive !== archiveBefore;
+
+  if (dryRun) {
+    console.log("[--check] would relocate; no files written.");
+  } else {
+    if (archiveChanged) fs.writeFileSync(ARCHIVE_PATH, archive);
+    if (registryChanged) fs.writeFileSync(REGISTRY_PATH, registry);
+  }
+
+  console.log(
+    [
+      `MEM_REGISTRY archival ${dryRun ? "(dry-run) " : ""}complete:`,
+      `  relocated:        ${stats.archivedKeys.join(", ") || "(none)"}`,
+      `  removedFromLive:  ${stats.removedFromLive}`,
+      `  newlyArchived:    ${stats.newlyArchived}`,
+      `  alreadyInArchive: ${stats.alreadyInArchive}`,
+      `  totalArchived:    ${stats.totalArchived}`,
+      `  liveRemovedAfter: ${stats.liveRemovedAfter}`,
+      `  registry size:    ${Buffer.byteLength(registryBefore)} → ${Buffer.byteLength(registry)} bytes`,
+      ...checks.map((c) => `  verify: ${c}`),
+    ].join("\n")
+  );
+}
+
+main();

--- a/skills/memory/scripts/mem-write.ts
+++ b/skills/memory/scripts/mem-write.ts
@@ -18,6 +18,7 @@ import * as fs from "fs";
 import { brainPath } from "./lib/brain-root.js";
 
 const REGISTRY_PATH = brainPath("memory/MEM_REGISTRY.md");
+const ARCHIVE_PATH = brainPath("memory/MEM_REGISTRY_ARCHIVE.md");
 const TODAY_PATH = brainPath("memory/TODAY.md");
 
 const REGISTRY_HEADER = `# MEM Registry
@@ -41,9 +42,14 @@ function scanMaxKey(filePath: string, pattern: RegExp): number {
 function getNextKey(): number {
   // REGISTRY rows are pipe-tabled (`| MEM-N | ACTIVE | ...`) and have no prose drift risk — full scan is safe and acts as defense-in-depth.
   const fromRegistry = scanMaxKey(REGISTRY_PATH, /MEM-(\d+)/g);
+  // MEM_REGISTRY_ARCHIVE.md holds REMOVED rows relocated out of the live registry
+  // (see mem-registry-archive.ts). If the highest-numbered key was REMOVED and
+  // archived, it no longer appears as a table row in the live registry — scan the
+  // archive too so the counter never reuses an archived number.
+  const fromArchive = scanMaxKey(ARCHIVE_PATH, /MEM-(\d+)/g);
   // TODAY.md mixes canonical write rows with prose mentions (e.g. review summaries). Restrict to anchored canonical rows: `- [MEM-N] ...`. Permit whitespace or colon after `]` for forward-compat with format drift.
   const fromToday = scanMaxKey(TODAY_PATH, /^- \[MEM-(\d+)\][\s:\]]/gm);
-  return Math.max(fromRegistry, fromToday) + 1;
+  return Math.max(fromRegistry, fromArchive, fromToday) + 1;
 }
 
 function ensureRegistry(): void {


### PR DESCRIPTION
## What & why

`MEM_REGISTRY.md` is append-only for audit reasons — REMOVED rows are never deleted (consolidate Step 1c), so the registry grows unbounded with **no in-channel reduction path**. On the vibe-keeper brain it is already 21598 B (4× the 5000 B threshold), 11 of those rows are dead REMOVED audit lines.

This adds a **deterministic** consolidate step (9d) that relocates dead REMOVED audit rows to `memory/MEM_REGISTRY_ARCHIVE.md`, leaving a single navigable pointer stub in the live registry. **ACTIVE / OBSOLETE rows and policy prose stay untouched** — relocating live content is a semantic judgment that remains with reflection (per DevGuru's scope split on poller-brain#175).

Home context: memory-reflection consult 2026-07-20 (DevGuru ACK, merge → Jakub).

## Acceptance (this PR — re-scoped)

This PR is the **mechanical half** of registry reduction. Its acceptance is:
- ✅ All REMOVED rows relocated (11/11), `live REMOVED count == 0`
- ✅ Count-verified before write (round-trip + count), aborts on any drop
- ✅ Idempotent (2nd run byte-identical no-op)
- ✅ Byte reduction from relocation: **21598 → 19463 B**

The original absolute `MEM_REGISTRY.md < 15000 B` was the target of the **combined** effort (mechanical relocation **+** manual condensation of the live HOLD-rule prose). That threshold moves to the manual/reflection follow-up **#218** — this PR intentionally does not touch live prose.

## DevGuru review conditions — all satisfied

| Condition | How |
|---|---|
| **Idempotent** — consolidate can run 2× (gap-day / reflection-only) | 2nd consecutive run is a **byte-identical no-op** (verified in E2E + test). REMOVED rows are gone; the regenerated stub is not a data row, so nothing is re-matched or duplicated. |
| **Count-verify (machine, not by eye)** | Script asserts `removedFromLive == newlyArchived + alreadyInArchive` **and** `live REMOVED count == 0` **and** round-trip (every relocated key present in archive) **before writing**; aborts (exit 1) on any violation → no silent drop. |
| **Stub = pointer, not bare deletion** | `> 📦 N REMOVED audit entries archived to [MEM_REGISTRY_ARCHIVE.md](...) — Keys: MEM-2, MEM-3, …` |

## Files

- `lib/mem-registry-archive-core.ts` — pure, fs-free relocation + `verifyStats()`
- `mem-registry-archive.ts` — CLI wrapper, self-verifying (aborts on any drop; `--check` dry-run)
- `mem-registry-archive.test.ts` — 31 fixture assertions (round-trip, idempotence, no-dup partial re-run, prose-with-"REMOVED" preserved, ACTIVE/OBSOLETE kept)
- `mem-write.ts` — also scans the archive for the max key, so an archived highest-numbered REMOVED key is never reused (integrity)
- `consolidate/skill.md` — Step 9d

## Validation output

Self-test:
```
$ npx tsx skills/memory/scripts/mem-registry-archive.test.ts
✅ all 31 assertions passed
```

E2E against the real vibe-keeper registry (idempotence):
```
=== RUN 1 ===
  relocated:        MEM-2, MEM-3, MEM-5, MEM-26, MEM-44, MEM-52, MEM-54, MEM-55, MEM-56, MEM-57, MEM-62
  removedFromLive:  11
  newlyArchived:    11
  alreadyInArchive: 0
  liveRemovedAfter: 0
  registry size:    21598 → 19463 bytes
  verify: round-trip: all 11 relocated keys present in archive ✅
  verify: count: removedFromLive(11) == newlyArchived(11) + alreadyInArchive(0) ✅
  verify: live REMOVED count after run == 0 ✅
=== RUN 2 (idempotence) ===
No REMOVED rows in live registry — already archived (11 in archive). No-op.
REGISTRY byte-identical ✅
ARCHIVE byte-identical ✅
```

Next-key safety (highest key REMOVED → archived → next mem-write must not reuse it): confirmed it assigns `MEM-3`, not `MEM-2`.

## Scope note (honest acceptance)

The original consult floated `MEM_REGISTRY.md < 15000 B` as acceptance. Mechanical REMOVED-relocation alone takes the vibe-keeper brain to **19463 B**, not under 15000 — the remaining bulk is **live** HOLD-rule policy prose (~4.5 KB) and 40+ ACTIVE rows, which this step deliberately does **not** touch. Relocating that prose is a separate manual/reflection judgment (same principle as keeping the LEARNINGS gate manual) — tracked as follow-up **#218**. The durable acceptance for this step is the machine invariants above: all REMOVED rows relocated, `live REMOVED == 0`, idempotent, round-trip verified.

## Tier

Tier-2 (base-brain `skills/memory/*`) → **merge = Jakub**. DevGuru ACK'd approach + conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
