### PR TITLE
Auto-improve: update-relevant-tiers

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -250,7 +250,11 @@ Users can ask you to report issues about the platform or base brain. When a user
     - Gaps: 2026-04-11 (had sessions per git log, no daily log written)
     ```
     Populate the `selfAssessment` fields `daily-log-exists-today`, `daily-log-continuous-appends`, `daily-log-recent-retention`, and `daily-log-weekly-coverage` based on this block.
-    **`daily-log-weekly-coverage` self-assessment rule:** Set to `true` only if the ratio in the compliance block is ≥ 0.8. If < 0.8, set to `false` AND add a `[self-critique]` entry in `processImprovements` explicitly naming the missing days and why (e.g., `[self-critique] Coverage 5/7 this week — 2026-04-11 and 2026-04-12 had sessions but no log written`). The evaluator reads the compliance block directly and ignores a `true` selfAssessment when the block shows < 0.8; the `[self-critique]` entry is the ONLY way to pass when coverage is below threshold.
+    **`daily-log-weekly-coverage` self-assessment rule:** Set to `true` only if the ratio in the compliance block is ≥ 0.8. If < 0.8, you MUST do BOTH of the following or this criterion automatically FAILS:
+    1. Set `selfAssessment.daily-log-weekly-coverage: false`
+    2. Add a `[self-critique]` entry in `processImprovements` naming the specific missing days and why (e.g., `[self-critique] Coverage 5/7 this week — 2026-04-11 and 2026-04-12 had sessions but no log written`)
+
+    The evaluator reads the compliance block directly and ignores a `true` selfAssessment when the block shows < 0.8. **Omitting the `[self-critique]` entry causes an automatic failure for this criterion — it is not optional.**
 
 ## Twice Weekly
 


### PR DESCRIPTION
## Auto-Improvement


**Target criterion:** update-relevant-tiers
**Eval date:** 2026-07-24
**Overall score:** 0.9429

### Recent Eval History
- evidence-backed-decisions: 100%
- previous-recommendations-reviewed: 100%
- reduce-log-count: 100%
- semantic-naming-convention: 100%
- summary-md-regenerated: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100% <-- TARGET
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** update-relevant-tiers (ambiguous: true)
**Files modified:** MAINTENANCE.md

### What changed

Strengthened the `daily-log-weekly-coverage` self-assessment rule in the Daily Log Compliance section. The previous wording buried the consequence of omitting the `[self-critique]` entry in a single dense sentence: "the `[self-critique]` entry is the ONLY way to pass when coverage is below threshold." This phrasing was easy to miss and didn't clearly state that omission causes an **automatic failure**.

The updated instruction:
- Enumerates the two required actions (set `false` + add `[self-critique]`) as a numbered list
- Adds a bolded callout: "Omitting the `[self-critique]` entry causes an automatic failure for this criterion — it is not optional."

### Why this addresses the situation

The improvement context had `ambiguous: true` with `target_criterion: update-relevant-tiers` (scoring 1.0). The real score drag is `daily-log-weekly-coverage: 0` (0% pass rate), which accounts for the gap between 1.0 and the 0.9429 overall score. Both criteria are in the Consolidation Criteria / Daily Log Compliance section of MAINTENANCE.md.

Report insights confirm some brains have low weekly coverage (consolidation-only stubs, idle weeks with sessions not logged) — exactly the scenario where the `[self-critique]` path applies. A 0% pass rate implies brains with coverage < 0.8 are consistently skipping the required `[self-critique]` entry because the previous wording didn't make the failure consequence clear enough.

### Expected impact

Brains with < 0.8 coverage should now clearly understand that the `[self-critique]` entry is mandatory and its absence = automatic failure. This should convert failing reports (coverage < 0.8, no `[self-critique]`) into passing reports (coverage < 0.8 with honest `[self-critique]`), improving the `daily-log-weekly-coverage` pass rate from 0 toward 1.0 and lifting the overall score from 0.9429.

### Report insights influence

The observations section confirmed "Daily logs since 2026-06-25 are pure consolidation-start stubs" and "13 of 14 daily-log entries since 07-23 are identical empty CD-backfill cron runs" — indicating coverage gaps are real and the self-critique acknowledgment path is the correct fix mechanism, not changing brain behavior around log creation.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*