### PR TITLE
Auto-improve: semantic-naming-convention

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -148,6 +148,8 @@ Route new/updated facts to appropriate locations:
 | Lessons | `memory/core/LEARNINGS.md` |
 | Mistakes | `memory/core/MISTAKES.md` |
 
+**Naming convention (enforced):** All new files created in `memory/semantic/`, `memory/episodic/`, and `memory/procedural/` MUST use kebab-case: all lowercase, hyphens only (no underscores, no spaces, no camelCase), `.md` extension. Examples: `stepforge.md`, `vest-liquidation.md`, `api-auth-flow.md`. Reject any filename that contains uppercase letters, underscores, or spaces before writing.
+
 ### 5. Promote Mistakes
 
 Review `memory/core/MISTAKES.md` for entries ready to be promoted. For each entry with status `new`:


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** semantic-naming-convention
**Eval date:** 2026-07-26
**Overall score:** 0.9548

### Recent Eval History
- evidence-backed-decisions: 100%
- previous-recommendations-reviewed: 100%
- reduce-log-count: 100%
- semantic-naming-convention: 86% <-- TARGET
- summary-md-regenerated: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100%
- verifiable-recommendations: 100%

### What Changed
## Improvement Summary

**Target criterion:** semantic-naming-convention
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Added an explicit naming convention enforcement note immediately after the Step 4 routing table in the consolidation skill. The note states that all new files created in `memory/semantic/`, `memory/episodic/`, and `memory/procedural/` must use kebab-case (all lowercase, hyphens only, `.md` extension), with examples and an explicit reject-before-write instruction.

Previously, the naming convention was documented only in the memory skill's "Session Capture" section, which is read during interactive sessions but not during consolidation runs. The consolidation skill's Step 4 (the primary code path where semantic files are created) had no naming convention reminder, making it easy for pollers to create files with underscores, camelCase, or other non-kebab-case names.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure run during maintenance heartbeat

**Behavior change:** When consolidation promotes facts to `memory/semantic/`, `memory/episodic/`, or `memory/procedural/`, the agent will now see an explicit enforcement note requiring kebab-case filenames before writing. This closes the gap where the naming convention was documented in the memory skill but not visible at the point of file creation during consolidation.

### Expected impact

Pollers running consolidation will see the kebab-case requirement at Step 4, the exact moment they create new semantic files. This should reduce violations from the ~14% historical fail rate toward 0%, improving the semantic-naming-convention pass rate from the 7-day historical average of 0.857 to close to 1.0.

### Report insights used

No specific report insight directly addressed semantic file naming. The fix was derived from the criterion definition and the structural gap between where the naming convention was documented (memory/skill.md) and where it is applied (consolidate/skill.md Step 4).

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*