### PR TITLE
fix(scheduled-msg): surface + document frozen delivery target (pb#124)

### DIFF
--- a/mcp/__tests__/teamvibe-api-delivery.test.mjs
+++ b/mcp/__tests__/teamvibe-api-delivery.test.mjs
@@ -1,0 +1,53 @@
+// Unit tests for the pb#124 delivery-target surfacing (option B): the
+// create_scheduled_message response echoes a `delivery` block so the agent can
+// verify a scheduled message reaches the intended recipient before trusting it.
+// teamvibe-api.mjs auto-starts a stdio server at the transport section, so we
+// load just the prelude (everything before the JSON-RPC section) as a module and
+// export the pure helper. No network, no stdin.
+// Run: node mcp/__tests__/teamvibe-api-delivery.test.mjs
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'teamvibe-api.mjs'), 'utf8')
+const prelude = src.split('// --- JSON-RPC 2.0 / MCP protocol ---')[0]
+const exports = '\nexport { buildDeliveryInfo }\n'
+const mod = await import('data:text/javascript,' + encodeURIComponent(prelude + exports))
+const { buildDeliveryInfo } = mod
+
+let pass = 0, fail = 0
+const ok = (n, c) => { if (c) { pass++; console.log('  ✓', n) } else { fail++; console.log('  ✗ FAIL', n) } }
+
+// 1) inherited from session (the pb#124 failure shape) → flagged, channel echoed, warning present
+{
+  const d = buildDeliveryInfo({ source: 'slack', channel: 'D_KUBA_DM', thread_ts: undefined }, false)
+  ok('1 channel echoed', d.channel === 'D_KUBA_DM')
+  ok('1 resolvedFrom = inherited', d.resolvedFrom === 'inherited-from-current-session')
+  ok('1 note warns about different recipient', /different channel\/recipient/.test(d.note))
+}
+// 2) explicit origin → marked explicit, no inheritance warning
+{
+  const d = buildDeliveryInfo({ source: 'slack', channel: 'C_PROJECT', thread_ts: '123.456' }, true)
+  ok('2 channel echoed', d.channel === 'C_PROJECT')
+  ok('2 thread_ts echoed', d.thread_ts === '123.456')
+  ok('2 resolvedFrom = explicit', d.resolvedFrom === 'explicit-origin')
+  ok('2 note = explicit, no warning', d.note === 'Delivery channel C_PROJECT (explicit).')
+}
+// 3) no origin resolved → resolvedFrom none, fallback note, null channel (never throws)
+{
+  const d = buildDeliveryInfo(undefined, false)
+  ok('3 channel null', d.channel === null)
+  ok('3 thread_ts null', d.thread_ts === null)
+  ok('3 resolvedFrom = none', d.resolvedFrom === 'none')
+  ok('3 note = channel default fallback', /fall back to the channel default/.test(d.note))
+}
+// 4) explicit origin object without a channel → explicit but null channel (no crash, honest fallback note)
+{
+  const d = buildDeliveryInfo({ source: 'slack' }, true)
+  ok('4 channel null', d.channel === null)
+  ok('4 resolvedFrom = explicit', d.resolvedFrom === 'explicit-origin')
+  ok('4 note = fallback', /fall back to the channel default/.test(d.note))
+}
+
+console.log(`\n${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)

--- a/mcp/__tests__/teamvibe-api-delivery.test.mjs
+++ b/mcp/__tests__/teamvibe-api-delivery.test.mjs
@@ -11,9 +11,9 @@ import { dirname, join } from 'node:path'
 
 const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'teamvibe-api.mjs'), 'utf8')
 const prelude = src.split('// --- JSON-RPC 2.0 / MCP protocol ---')[0]
-const exports = '\nexport { buildDeliveryInfo }\n'
+const exports = '\nexport { buildDeliveryInfo, buildScheduleResponse }\n'
 const mod = await import('data:text/javascript,' + encodeURIComponent(prelude + exports))
-const { buildDeliveryInfo } = mod
+const { buildDeliveryInfo, buildScheduleResponse } = mod
 
 let pass = 0, fail = 0
 const ok = (n, c) => { if (c) { pass++; console.log('  ✓', n) } else { fail++; console.log('  ✗ FAIL', n) } }
@@ -47,6 +47,32 @@ const ok = (n, c) => { if (c) { pass++; console.log('  ✓', n) } else { fail++;
   ok('4 channel null', d.channel === null)
   ok('4 resolvedFrom = explicit', d.resolvedFrom === 'explicit-origin')
   ok('4 note = fallback', /fall back to the channel default/.test(d.note))
+}
+
+// (5) response key order — the poller truncates a logged tool_result at 200 chars,
+// and the stored row echoes back promptTemplate, which is unbounded. Behind the
+// row, delivery never reaches the session log.
+{
+  const truncate = (s) => (s.length > 200 ? s.slice(0, 200) + '...' : s) // claude-spawner.ts truncateOutput
+  const row = {
+    scheduleId: '01KYH000000000000000000000',
+    workspaceId: 'W1',
+    scheduleType: 'ONE_TIME',
+    promptTemplate: 'Zkontroluj stav PR a pokud je zeleny, napis do vlakna shrnuti; jinak vypis duvod selhani a navrhni dalsi krok.',
+    origin: { channel: 'C_TARGET', thread_ts: '1.1', source: 'slack' },
+  }
+  const r = buildScheduleResponse(row, row.origin, true)
+  const keys = Object.keys(r)
+  ok('5 delivery precedes the stored row', keys[0] === 'delivery')
+  ok('5 delivery survives truncation', truncate(JSON.stringify(r)).includes('"channel":"C_TARGET"'))
+  ok('5 row fields still returned in full', r.scheduleId === row.scheduleId && r.promptTemplate === row.promptTemplate)
+
+  const old = JSON.stringify({ ...row, delivery: r.delivery })
+  ok('5 old order would have lost it', !truncate(old).includes('resolvedFrom'))
+
+  ok('5 non-object result is wrapped, not spread', buildScheduleResponse('nope', null, false).result === 'nope')
+  const clash = buildScheduleResponse({ ...row, delivery: { channel: 'C_SERVER' } }, row.origin, true)
+  ok('5 our delivery block wins over a server-side one', clash.delivery.channel === 'C_TARGET')
 }
 
 console.log(`\n${pass} passed, ${fail} failed`)

--- a/mcp/teamvibe-api.mjs
+++ b/mcp/teamvibe-api.mjs
@@ -86,6 +86,42 @@ function annotateSchedule(row) {
   return { ...local, ...row }
 }
 
+// Build the delivery-target hint echoed back to the agent so it can verify a
+// scheduled message will reach the intended recipient. origin.channel is frozen
+// at create time and replayed every run; when it is inherited from the current
+// session it may be a DM or a different channel than intended (poller-brain#124).
+function buildDeliveryInfo(origin, wasExplicit) {
+  const channel = origin?.channel || null
+  return {
+    channel,
+    thread_ts: origin?.thread_ts || null,
+    resolvedFrom: wasExplicit
+      ? 'explicit-origin'
+      : channel
+        ? 'inherited-from-current-session'
+        : 'none',
+    note: channel
+      ? wasExplicit
+        ? `Delivery channel ${channel} (explicit).`
+        : `Delivery channel ${channel} was inherited from the CURRENT session. If this schedule is meant for a different channel/recipient, re-create it with an explicit origin.channel.`
+      : 'No origin.channel resolved — runs fall back to the channel default target.',
+  }
+}
+
+// Assembles the create_scheduled_message response. `delivery` goes ahead of
+// everything else: `annotateSchedule` already puts the rendered *Local fields
+// ahead of the raw row for the same reason (promptTemplate has no length
+// ceiling, and the poller truncates a logged tool_result at 200 chars —
+// claude-spawner.ts truncateOutput). Behind the row, delivery would never
+// reach the session log. Short/telemetry fields up, echoes down (#184).
+function buildScheduleResponse(result, storedOrigin, wasExplicit) {
+  // Our block is authoritative — drop a server-side `delivery` rather than let
+  // the spread reinstate it further down the object under the same name.
+  const { delivery: _serverDelivery, ...row } =
+    result && typeof result === 'object' ? result : { result }
+  return { delivery: buildDeliveryInfo(storedOrigin, wasExplicit), ...annotateSchedule(row) }
+}
+
 const TOOLS = [
   {
     name: 'list_scheduled_messages',
@@ -113,7 +149,7 @@ const TOOLS = [
         status: { type: 'string', enum: ['ACTIVE', 'PAUSED'], description: 'Schedule status (default: ACTIVE)' },
         origin: {
           type: 'object',
-          description: 'Origin context for response routing. Auto-populated from Slack env vars if not provided.',
+          description: 'Origin context for response routing — which Slack channel/thread the scheduled run delivers to. Auto-populated from the CURRENT session Slack channel if omitted, and FROZEN at create time (replayed on every run). Pass explicitly (esp. origin.channel) when the schedule targets a different channel/recipient than this session — e.g. scheduling from a DM for a project channel.',
           properties: {
             source: { type: 'string', enum: ['slack', 'heartbeat', 'email', 'api'] },
             channel: { type: 'string' },
@@ -190,7 +226,11 @@ async function handleTool(name, args) {
       if (args.timezone) body.timezone = args.timezone
       if (args.status) body.status = args.status
 
-      // Auto-populate origin from environment if not explicitly provided
+      // Auto-populate origin from environment if not explicitly provided.
+      // NOTE: origin.channel is FROZEN onto the schedule at create time and
+      // replayed on every run. When inherited here it is THIS session's Slack
+      // channel — which may be a DM or a different channel than the schedule is
+      // meant for (see poller-brain#124).
       if (args.origin) {
         body.origin = args.origin
       } else if (process.env.SLACK_CHANNEL) {
@@ -201,7 +241,14 @@ async function handleTool(name, args) {
         }
       }
 
-      return annotateSchedule(await apiCall('POST', '/scheduled-messages', body))
+      const result = await apiCall('POST', '/scheduled-messages', body)
+
+      // Surface the resolved delivery target so the agent can verify it matches
+      // the intended recipient before trusting the schedule (poller-brain#124, option B).
+      return {
+        ...annotateSchedule(result && typeof result === 'object' ? result : { result }),
+        delivery: buildDeliveryInfo(body.origin, Boolean(args.origin)),
+      }
     }
 
     case 'delete_scheduled_message': {

--- a/mcp/teamvibe-api.mjs
+++ b/mcp/teamvibe-api.mjs
@@ -245,10 +245,11 @@ async function handleTool(name, args) {
 
       // Surface the resolved delivery target so the agent can verify it matches
       // the intended recipient before trusting the schedule (poller-brain#124, option B).
-      return {
-        ...annotateSchedule(result && typeof result === 'object' ? result : { result }),
-        delivery: buildDeliveryInfo(body.origin, Boolean(args.origin)),
-      }
+      // Prefer the origin the server actually STORED (ground truth) over the one we
+      // sent, so the block stays honest if the platform ever normalizes origin
+      // server-side (e.g. option C) — fall back to body.origin when not echoed.
+      const storedOrigin = (result && typeof result === 'object' && result.origin) || body.origin
+      return buildScheduleResponse(result, storedOrigin, Boolean(args.origin))
     }
 
     case 'delete_scheduled_message': {

--- a/skills/teamvibe-api/skill.md
+++ b/skills/teamvibe-api/skill.md
@@ -26,6 +26,20 @@ Create or update a schedule.
 | `endDate` | no | Optional end date for recurring schedules |
 | `scheduleId` | no | Pass existing ID to update a schedule |
 | `status` | no | `ACTIVE` (default) or `PAUSED` |
+| `origin` | no | *Delivery target* (`channel`, `thread_ts`, `source`) for the scheduled runs. Auto-inherits **this session's** channel if omitted, and is **frozen** at create time — see the warning below. |
+
+> ⚠️ **Delivery target is frozen from the creating session.** If you omit `origin`, the schedule's delivery channel is captured from **the Slack channel you are in right now** and replayed on every run. Create a schedule from a **DM** (or any channel that isn't the intended recipient) and every run is delivered *there*, not where you meant. This caused a real misdelivery — a reminder went to the wrong person's DM ([poller-brain#124](https://github.com/teamvibeai/poller-brain/issues/124)).
+>
+> **Rule:** when the schedule is meant for a **different channel/recipient than your current session**, pass `origin` explicitly:
+> ```json
+> {
+>   "scheduleType": "ONE_TIME",
+>   "scheduledAt": "2026-03-15T09:00:00Z",
+>   "promptTemplate": "Post: 'Reminder: ...'",
+>   "origin": { "source": "slack", "channel": "C0PROJECT123" }
+> }
+> ```
+> The `create_scheduled_message` response echoes a `delivery` block with the resolved `channel` and a `resolvedFrom` flag (`inherited-from-current-session` vs `explicit-origin`) — **verify it matches the intended recipient** before trusting the schedule.
 
 ### list_scheduled_messages
 


### PR DESCRIPTION
## What & why

Scheduled messages **freeze `origin.channel` from the creating session** (`SLACK_CHANNEL`) at create time and replay it on every run, with **no cross-channel validation**. A schedule created from a DM therefore delivers to that DM forever — the [pb#124](https://github.com/teamvibeai/poller-brain/issues/124) misdelivery (a reminder went to the wrong person's DM).

Root cause chain (verified in code):
1. `mcp/teamvibe-api.mjs` — when the agent omits `origin`, the tool auto-fills `origin.channel = process.env.SLACK_CHANNEL` (the raw channel of *this* session, possibly a DM).
2. Stored frozen on the schedule row (`poller-scheduled-messages.ts:157`).
3. Replayed every run (`scheduler.ts:89-102`) → `SLACK_CHANNEL` env → `send_message` default. No guard anywhere.

## This PR — options A + B (base-brain)

**A — docs (`skills/teamvibe-api/skill.md`):** documents the previously-undocumented `origin` param, adds a ⚠️ callout that the delivery target is frozen from the creating session, and shows the explicit-origin pattern for cross-channel schedules.

**B — visibility (`mcp/teamvibe-api.mjs`):** `create_scheduled_message` now echoes a `delivery` block so the agent can verify the resolved target before trusting the schedule:
```json
"delivery": {
  "channel": "D_KUBA_DM",
  "thread_ts": null,
  "resolvedFrom": "inherited-from-current-session",
  "note": "Delivery channel D_KUBA_DM was inherited from the CURRENT session. If this schedule is meant for a different channel/recipient, re-create it with an explicit origin.channel."
}
```
`resolvedFrom` flags `inherited-from-current-session` vs `explicit-origin`. The tool's `origin` schema description is also strengthened. Logic extracted to a pure `buildDeliveryInfo()`.

## Tests

`mcp/__tests__/teamvibe-api-delivery.test.mjs` — 14 assertions (inherited / explicit / none / explicit-without-channel). Existing slack MCP tests unchanged (18 + 20 pass). `node --check` clean.

## Not in this PR — option D (platform, follow-up)

A deterministic cross-channel guard belongs in the platform (`scheduler.ts` / create path) so it catches the whole fleet regardless of agent adherence. Tracked as a follow-up `teamvibe.ai` issue (link in comments). This PR is the immediate config+visibility fallback.

## Review

Base-brain MCP + skill change → **DevGuru approach review** requested, **Tier-2 merge by @jakubknejzlik**. `pb#124` closed manually on merge (cross-repo).
