### PR TITLE
feat(teamvibe-api): render schedule timestamps in the schedule timezone with weekday

### DIFF
--- a/mcp/__tests__/teamvibe-api-schedule-time.test.mjs
+++ b/mcp/__tests__/teamvibe-api-schedule-time.test.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Unit tests for formatLocalTime() / annotateSchedule() — the schedule timestamp
+// rendering added for #240 (follow-up to the #145 false positive).
+//
+// The load-bearing case is #145 itself: a schedule that ran correctly was reported
+// as having skipped a Thursday. Rendered in its own timezone with the weekday, the
+// report refutes itself. If that assertion ever fails, the fix stopped working.
+//
+// teamvibe-api.mjs auto-starts a stdio server on import, so we load just the pure
+// prelude (everything before the transport section) and export-by-eval the helpers.
+// No network, no API. Run: node mcp/__tests__/teamvibe-api-schedule-time.test.mjs
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'teamvibe-api.mjs'), 'utf8')
+const prelude = src
+  .split('// --- JSON-RPC 2.0 / MCP protocol ---')[0]
+  .split('\n')
+  .filter((l) => !l.startsWith('import '))
+  .join('\n')
+const exports = '\nexport { formatLocalTime, annotateSchedule }\n'
+const mod = await import('data:text/javascript,' + encodeURIComponent(prelude + exports))
+const { formatLocalTime, annotateSchedule } = mod
+
+let pass = 0, fail = 0
+const ok = (n, c) => { if (c) { pass++; console.log('  ✓', n) } else { fail++; console.log('  ✗ FAIL', n) } }
+const eq = (n, actual, expected) => {
+  if (actual === expected) { pass++; console.log('  ✓', n) }
+  else { fail++; console.log('  ✗ FAIL', n, '\n      expected:', expected, '\n      actual:  ', actual) }
+}
+
+console.log('formatLocalTime — weekday + wall clock in the schedule timezone')
+{
+  // #145: "skipped Thursday 2026-05-29". lastRunAt renders as Thursday 18:00 Prague,
+  // i.e. the Thursday run happened; 2026-05-29 was a Friday, which `1-4` excludes.
+  eq('#145 lastRunAt is Thursday in Europe/Prague',
+    formatLocalTime('2026-05-28T16:00:17Z', 'Europe/Prague'),
+    'Thu 2026-05-28 18:00:17 (Europe/Prague)')
+  eq('#145 nextRunAt is Monday in Europe/Prague',
+    formatLocalTime('2026-06-01T16:00:00Z', 'Europe/Prague'),
+    'Mon 2026-06-01 18:00:00 (Europe/Prague)')
+
+  // The date the report claimed was a Thursday.
+  ok('2026-05-29 renders as Friday, not Thursday',
+    formatLocalTime('2026-05-29T16:00:00Z', 'Europe/Prague').startsWith('Fri '))
+}
+
+console.log('formatLocalTime — offsets, DST and midnight')
+{
+  eq('missing timezone falls back to UTC and says so',
+    formatLocalTime('2026-05-28T16:00:17Z', undefined),
+    'Thu 2026-05-28 16:00:17 (UTC)')
+  eq('CET (winter, UTC+1)',
+    formatLocalTime('2026-01-15T08:00:00Z', 'Europe/Prague'),
+    'Thu 2026-01-15 09:00:00 (Europe/Prague)')
+  eq('CEST (summer, UTC+2)',
+    formatLocalTime('2026-07-15T08:00:00Z', 'Europe/Prague'),
+    'Wed 2026-07-15 10:00:00 (Europe/Prague)')
+  // Crossing local midnight is where a UTC-only reading flips the weekday.
+  eq('UTC evening is already the next day in Tokyo',
+    formatLocalTime('2026-05-28T16:00:00Z', 'Asia/Tokyo'),
+    'Fri 2026-05-29 01:00:00 (Asia/Tokyo)')
+  eq('midnight renders as 00, not 24',
+    formatLocalTime('2026-05-28T22:00:00Z', 'Europe/Prague'),
+    'Fri 2026-05-29 00:00:00 (Europe/Prague)')
+}
+
+console.log('formatLocalTime — refuses to guess')
+{
+  ok('unknown IANA zone annotates nothing', formatLocalTime('2026-05-28T16:00:17Z', 'Mars/Olympus') === undefined)
+  ok('unparseable timestamp annotates nothing', formatLocalTime('not-a-date', 'Europe/Prague') === undefined)
+  ok('empty string annotates nothing', formatLocalTime('', 'Europe/Prague') === undefined)
+  ok('null annotates nothing', formatLocalTime(null, 'Europe/Prague') === undefined)
+  ok('non-string annotates nothing', formatLocalTime(1748448017000, 'Europe/Prague') === undefined)
+}
+
+console.log('annotateSchedule — additive, ordered, defensive')
+{
+  const row = {
+    scheduleId: '01KP8M2VNCXHK3VB1TFES48YJE',
+    scheduleType: 'CRON',
+    cronExpression: '0 18 * * 1-4',
+    timezone: 'Europe/Prague',
+    status: 'ACTIVE',
+    lastRunAt: '2026-05-28T16:00:17Z',
+    nextRunAt: '2026-06-01T16:00:00Z',
+    promptTemplate: 'x'.repeat(5000),
+  }
+  const out = annotateSchedule(row)
+
+  eq('lastRunAtLocal added', out.lastRunAtLocal, 'Thu 2026-05-28 18:00:17 (Europe/Prague)')
+  eq('nextRunAtLocal added', out.nextRunAtLocal, 'Mon 2026-06-01 18:00:00 (Europe/Prague)')
+  eq('original lastRunAt untouched', out.lastRunAt, row.lastRunAt)
+  eq('original nextRunAt untouched', out.nextRunAt, row.nextRunAt)
+  eq('promptTemplate untouched', out.promptTemplate, row.promptTemplate)
+  ok('input not mutated', row.lastRunAtLocal === undefined)
+
+  // Response-shape rule: promptTemplate has no ceiling, so anything below it is what
+  // a truncated log drops first. Annotations must sit above it.
+  const keys = Object.keys(out)
+  ok('annotations precede promptTemplate',
+    keys.indexOf('lastRunAtLocal') < keys.indexOf('promptTemplate') &&
+    keys.indexOf('nextRunAtLocal') < keys.indexOf('promptTemplate'))
+}
+
+{
+  // ONE_TIME rows are stored with timezone: null (the API drops it for non-CRON).
+  const out = annotateSchedule({
+    scheduleType: 'ONE_TIME',
+    timezone: null,
+    scheduledAt: '2026-05-29T07:30:00Z',
+    status: 'ACTIVE',
+  })
+  eq('scheduledAt rendered in UTC when the row has no timezone',
+    out.scheduledAtLocal, 'Fri 2026-05-29 07:30:00 (UTC)')
+  ok('no nextRunAtLocal invented when nextRunAt is absent', out.nextRunAtLocal === undefined)
+}
+
+{
+  const noTimes = { scheduleId: 'x', status: 'PAUSED' }
+  ok('row with no timestamps returned unchanged', annotateSchedule(noTimes) === noTimes)
+  ok('null passes through', annotateSchedule(null) === null)
+  ok('array passes through', Array.isArray(annotateSchedule([1, 2])))
+  ok('string passes through', annotateSchedule('nope') === 'nope')
+}
+
+console.log(`\n${pass} passed, ${fail} failed`)
+process.exit(fail === 0 ? 0 : 1)

--- a/mcp/teamvibe-api.mjs
+++ b/mcp/teamvibe-api.mjs
@@ -30,10 +30,66 @@ async function apiCall(method, path, body) {
   return data
 }
 
+// --- schedule timestamp rendering (#240) ---
+//
+// Stored schedules carry bare ISO-UTC timestamps. Reading one then means converting
+// UTC -> schedule timezone -> weekday in your head, with nothing to check the result
+// against — which is how #145 got filed as a day-of-week bug against a schedule that
+// had run correctly (the "skipped Thursday" was a Friday). These fields render what
+// the server already decided, in the schedule's own timezone, weekday spelled out.
+//
+// Deliberately NOT a preview of upcoming runs: `nextRunAt` is computed server-side by
+// cron-parser, and a locally recomputed occurrence list that disagreed with it would
+// be worse than none. Rendering only, no cron evaluation, no dependencies.
+
+const LOCAL_TIME_FIELDS = [
+  ['lastRunAt', 'lastRunAtLocal'],
+  ['nextRunAt', 'nextRunAtLocal'],
+  ['scheduledAt', 'scheduledAtLocal'],
+]
+
+function formatLocalTime(iso, timezone) {
+  if (typeof iso !== 'string' || !iso) return undefined
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return undefined
+  const tz = timezone || 'UTC'
+  let parts
+  try {
+    parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: tz,
+      weekday: 'short',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(date)
+  } catch {
+    return undefined // unknown IANA zone — annotate nothing rather than render a wrong offset
+  }
+  const p = Object.fromEntries(parts.map((x) => [x.type, x.value]))
+  return `${p.weekday} ${p.year}-${p.month}-${p.day} ${p.hour}:${p.minute}:${p.second} (${tz})`
+}
+
+function annotateSchedule(row) {
+  if (!row || typeof row !== 'object' || Array.isArray(row)) return row
+  const local = {}
+  for (const [source, target] of LOCAL_TIME_FIELDS) {
+    const rendered = formatLocalTime(row[source], row.timezone)
+    if (rendered) local[target] = rendered
+  }
+  if (Object.keys(local).length === 0) return row
+  // Annotations first: `promptTemplate` has no length ceiling, and anything below it
+  // is the first thing a truncated log drops. Original fields keep their exact values.
+  return { ...local, ...row }
+}
+
 const TOOLS = [
   {
     name: 'list_scheduled_messages',
-    description: 'List scheduled messages for the current workspace/channel. Returns all schedules with their status, cron expression, and next run time.',
+    description: 'List scheduled messages for the current workspace/channel. Returns all schedules with their status, cron expression, and next run time. Run timestamps are ISO-UTC; the matching *Local fields render them in the schedule timezone with the weekday — read those before concluding a schedule misfired.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -43,7 +99,7 @@ const TOOLS = [
   },
   {
     name: 'create_scheduled_message',
-    description: 'Create or update a scheduled message. For recurring schedules use CRON type with a cron expression. For one-time schedules use ONE_TIME type with scheduledAt.',
+    description: 'Create or update a scheduled message. For recurring schedules use CRON type with a cron expression. For one-time schedules use ONE_TIME type with scheduledAt. The response echoes the stored row including nextRunAt and nextRunAtLocal (schedule timezone + weekday) — check it fires when you intended.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -115,7 +171,9 @@ async function handleTool(name, args) {
       const channelId = args.channelId || CHANNEL_ID
       const params = new URLSearchParams({ workspaceId: WORKSPACE_ID })
       if (channelId) params.set('channelId', channelId)
-      return await apiCall('GET', `/scheduled-messages?${params}`)
+      const result = await apiCall('GET', `/scheduled-messages?${params}`)
+      if (!Array.isArray(result?.items)) return result
+      return { ...result, items: result.items.map(annotateSchedule) }
     }
 
     case 'create_scheduled_message': {
@@ -143,7 +201,7 @@ async function handleTool(name, args) {
         }
       }
 
-      return await apiCall('POST', '/scheduled-messages', body)
+      return annotateSchedule(await apiCall('POST', '/scheduled-messages', body))
     }
 
     case 'delete_scheduled_message': {

--- a/skills/teamvibe-api/skill.md
+++ b/skills/teamvibe-api/skill.md
@@ -31,6 +31,8 @@ Create or update a schedule.
 
 List all schedules for the current channel. No required parameters.
 
+Every run timestamp comes back twice: the stored ISO-UTC value (`lastRunAt`, `nextRunAt`, `scheduledAt`) and a rendered `*Local` twin in the schedule's own timezone with the weekday — `"lastRunAtLocal": "Thu 2026-05-28 18:00:17 (Europe/Prague)"`. Read the `*Local` field. See [Verifying a schedule](#verifying-a-schedule).
+
 ### delete_scheduled_message
 
 | Parameter | Required | Description |
@@ -136,6 +138,21 @@ User: "Change that PR check to 9am instead"
 - **ONE_TIME:** `timezone` is **not used**. `scheduledAt` must be UTC (with `Z` suffix). Convert local times to UTC before sending.
 - If the user doesn't specify their timezone for CRON schedules, ask once and remember in MEMORY.md.
 - Common timezones: `Europe/Prague`, `America/New_York`, `America/Los_Angeles`, `Asia/Tokyo`
+
+## Verifying a schedule
+
+Before concluding that a schedule misfired — and **always** before filing a bug about one — check it against the rendered timestamps rather than your own arithmetic.
+
+**Never assert a weekday from a date without computing it.** This is not a style rule; it is the failure that produced [#145](https://github.com/teamvibeai/poller-brain/issues/145). A schedule on `0 18 * * 1-4` (Mon–Thu) was reported as having skipped Thursday `2026-05-29`. That date was a **Friday**, the Thursday run had happened normally, and the resulting bug report against the scheduler cost a full diagnosis cycle. The stored row said everything needed to refute it — but only in UTC, so the check was never made.
+
+The routine:
+
+1. Read `lastRunAtLocal` and `nextRunAtLocal`, not `lastRunAt` / `nextRunAt`. They carry the weekday and the schedule's own timezone.
+2. Confirm both weekdays are allowed by the day-of-week field of `cronExpression`. If the last run and the next run both sit inside the pattern, nothing was skipped — a gap over excluded days is the schedule working.
+3. Remember what `lastRunAt` actually means: the run was **enqueued** at that moment, not necessarily delivered. It is evidence the scheduler fired, not evidence you received anything.
+4. If you still believe a run was missed, say what you checked and what remains unexplained. "`nextRunAt` jumped from Thu to Mon and `1-4` includes Thursday" is a claim; "Thursday's run is absent from `lastRunAtLocal` although the previous and following occurrences both landed" is evidence.
+
+After `create_scheduled_message`, the response echoes the stored row with `nextRunAtLocal` — one glance confirms the cron means what you intended before you walk away from it.
 
 ## Common cron patterns
 


### PR DESCRIPTION
## Summary

Follow-up to [#145](https://github.com/teamvibeai/poller-brain/issues/145), option B. #145 was filed as a scheduler day-of-week bug and turned out to be a false positive — the reporting agent inferred a weekday from a UTC date without computing it and had no way to check the result (`2026-05-29` read as Thursday; it was Friday). Analysis: [issuecomment-5092095453](https://github.com/teamvibeai/poller-brain/issues/145#issuecomment-5092095453). Closes #145's underlying tool-surface gap; tracked in #240.

- `mcp/teamvibe-api.mjs` — `list_scheduled_messages` and `create_scheduled_message` now annotate `lastRunAt` / `nextRunAt` / `scheduledAt` with a rendered `*Local` twin: schedule's own timezone, weekday spelled out (`"lastRunAtLocal": "Thu 2026-05-28 18:00:17 (Europe/Prague)"`). Zero deps — `Intl.DateTimeFormat`.
- `skills/teamvibe-api/skill.md` — new "Verifying a schedule" section + standing rule: never assert a weekday from a date without computing it.

**Deliberately not doing:** a preview of the next N occurrences. That would need a cron parser in the base brain (dependency × every cloned brain — #184 constraint) and, more importantly, a second source of truth alongside the server's `nextRunAt` (computed by the real `cron-parser` in `poller-scheduled-messages.ts` / `scheduler.ts`). A locally recomputed preview that disagreed with the server would be worse than none. This only renders what the server already decided.

## DevGuru review

Approach reviewed and GO'd — 3 points raised, all accepted as-is:
1. No N-occurrence preview — agreed, server is the single source of truth, one occurrence is enough.
2. Silent fallback (field omitted) instead of guessing on unknown timezone / bad timestamp — correct per MEM-104 (a guessed default is a fabricated data point).
3. Annotations ordered above `promptTemplate` (which has no length ceiling) and pinned by test, not comment — MEM-100 (response-shape rule).

## Test plan

- [x] `node mcp/__tests__/teamvibe-api-schedule-time.test.mjs` — 26/26 pass. Load-bearing case is #145 itself: `lastRunAt=2026-05-28T16:00:17Z` renders `Thu 2026-05-28 18:00:17 (Europe/Prague)`, `2026-05-29T...` renders `Fri`.
- [x] Existing suites unaffected: `slack-payload.test.mjs` 20/20, `slack-convert.test.mjs` 18/18.
- [x] `node --check mcp/teamvibe-api.mjs` clean.
- [x] Validated against 92 live rows pulled from `list_scheduled_messages` in this workspace: all 92 annotated, zero original fields mutated, key order holds (proves the logic against real data, not just the stub — MEM-121).
