### PR TITLE
feat(mcp): set_expected_duration tool for tv#32 Layer B progress notifications

### DIFF
--- a/mcp/__tests__/slack-expected-duration.test.mjs
+++ b/mcp/__tests__/slack-expected-duration.test.mjs
@@ -1,0 +1,46 @@
+// Unit tests for the set_expected_duration tool handler (tv#32 Layer B).
+// This tool makes no Slack API call — it's purely a signal the poller reads
+// off the stdout stream — so handleTool() for this one case is safe to call
+// directly without mocking network I/O. Same load-the-prelude trick as
+// slack-payload.test.mjs since slack.mjs auto-starts a stdio server on import.
+// Run: node mcp/__tests__/slack-expected-duration.test.mjs
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'slack.mjs'), 'utf8')
+const prelude = src.split('// --- stdio transport ---')[0]
+const exports = '\nexport { handleTool, TOOLS }\n'
+const mod = await import('data:text/javascript,' + encodeURIComponent(prelude + exports))
+const { handleTool, TOOLS } = mod
+
+let pass = 0, fail = 0
+const ok = (n, c) => { if (c) { pass++; console.log('  ✓', n) } else { fail++; console.log('  ✗ FAIL', n) } }
+
+{
+  const r = await handleTool('set_expected_duration', { minutes: 12 })
+  ok('accepts a positive number, echoes it back', r.ok === true && r.minutes === 12)
+}
+
+{
+  const r = await handleTool('set_expected_duration', { minutes: '7' })
+  ok('coerces a numeric string', r.ok === true && r.minutes === 7)
+}
+
+for (const bad of [0, -5, NaN, 'not-a-number', undefined]) {
+  let threw = false
+  try {
+    await handleTool('set_expected_duration', { minutes: bad })
+  } catch {
+    threw = true
+  }
+  ok(`rejects invalid minutes: ${bad}`, threw)
+}
+
+{
+  const def = TOOLS.find((t) => t.name === 'set_expected_duration')
+  ok('tool is registered in TOOLS with a minutes schema', def?.inputSchema?.required?.includes('minutes'))
+}
+
+console.log(`\n${pass} passed, ${fail} failed`)
+if (fail) process.exit(1)

--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -708,6 +708,17 @@ const TOOLS = [
       required: ['text'],
     },
   },
+  {
+    name: 'set_expected_duration',
+    description: 'Tell the platform roughly how long the work you are about to do will take, so the user gets proactive progress updates if it runs long (0-5 min: no update needed, 5-10 min: one update, 10-15 min: two updates, 15+ min: three updates). Call this once, early, when you can already tell a task will take a while (e.g. a large multi-file refactor or deep research) — not required for normal quick replies. This does not affect timeouts or safety limits, only how often the user hears from you.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        minutes: { type: 'number', description: 'Your best-guess estimate of total time this task will take, in minutes' },
+      },
+      required: ['minutes'],
+    },
+  },
 ]
 
 // --- Tool handlers ---
@@ -1112,6 +1123,19 @@ async function handleTool(name, args) {
         status: args.text,
       })
       return { ok: true }
+    }
+
+    case 'set_expected_duration': {
+      // No Slack API call — this tool exists purely as a signal. The poller
+      // reads this tool_use event directly off the Claude Code stdout stream
+      // (packages/poller/src/claude-spawner.ts) and drives the tiered
+      // progress-notification schedule from it. Nothing to do here but
+      // validate and acknowledge.
+      const minutes = Number(args.minutes)
+      if (!Number.isFinite(minutes) || minutes <= 0) {
+        throw new Error('minutes must be a positive number')
+      }
+      return { ok: true, minutes }
     }
 
     default:


### PR DESCRIPTION
New MCP tool letting the agent self-report an expected task duration early in a run, so the poller can send tiered progress notifications on long-running work (0-5min silent / 5-10min 1x / 10-15min 2x / 15+min 3x).

Pure signal, no Slack API call in the handler itself — teamvibeai/teamvibe.ai#266 reads the `tool_use` event directly off Claude Code's stdout stream (`claude-spawner.ts`) and drives the actual notification schedule from it. That PR also implements Layer A of tv#32 (compaction-aware kill-deadline), which does NOT depend on this tool — self-report is only ever used for notification cadence, never the safety kill decision.

Tests: `node mcp/__tests__/slack-expected-duration.test.mjs` — 8/8 pass. Other mcp/slack tests unaffected (26/26, 18/18, 37/37 still green).

**Not merging yet** — requesting DevGuru review first per explicit instruction in C0BJFTSCAP4 thread.

cc @DevGuru