### PR TITLE
Auto-improve: previous-recommendations-reviewed

### DIFF
--- a/skills/memory/skill.md
+++ b/skills/memory/skill.md
@@ -167,14 +167,14 @@ Follow these steps when a session produces substantial reference material:
 
 ### Session Capture File Template
 
-Use this recommended structure for `semantic/` files created during session capture:
+Use this structure for `semantic/` files created during session capture:
 
 ```markdown
 # {Topic Name}
 <!-- WIP: topic not concluded -->  ← only if unfinished
 
 ## Context
-Brief description of what this is about and why.
+Brief description of what this is about and why it was captured.
 
 ## Decisions
 - What was agreed and why.
@@ -189,7 +189,7 @@ Brief description of what this is about and why.
 - Links, tools, examples.
 ```
 
-Not all sections are required — use what fits the content.
+**`## Context` is REQUIRED** — every session-capture file must include it with at least one line of text explaining what the file is about and why it was created. Without context, the file becomes opaque after a few weeks. Other sections (`## Decisions`, `## Considered Alternatives`, etc.) are optional — use what fits the content.
 
 ### Naming Convention
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** previous-recommendations-reviewed
**Eval date:** 2026-07-31
**Overall score:** 0.9035

### Recent Eval History
- evidence-backed-decisions: 100%
- previous-recommendations-reviewed: 100% <-- TARGET
- reduce-log-count: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100%

### What Changed
## Improvement Summary

**Target criterion:** session-capture-has-context (0% pass rate — worst scoring criterion; `ambiguous: true` in improvement context allowed targeting this over the named `previous-recommendations-reviewed` which already scores 100%)
**Files modified:** skills/memory/skill.md

### What changed

In the Session Capture File Template section, changed the closing note from "Not all sections are required — use what fits the content" to explicitly mark `## Context` as **REQUIRED** with a clear explanation of why (files become opaque without it), while keeping the remaining sections optional.

Before:
```
Not all sections are required — use what fits the content.
```

After:
```
**`## Context` is REQUIRED** — every session-capture file must include it with at least one line
of text explaining what the file is about and why it was created. Without context, the file
becomes opaque after a few weeks. Other sections are optional — use what fits the content.
```

### Skill Impact

**Skill:** memory — Memory management system governing how agents read, write, and organize memory
**Behavior change:** Session-capture files written to `memory/semantic/` during regular sessions will now always include a `## Context` section, because the skill template explicitly requires it rather than listing it as an optional section alongside all others. Brains following the template will add the context heading by default.

### Expected impact

The `session-capture-has-context` criterion passes when every semantic/ file from regular sessions includes `## Context` with substantive text. The prior template ambiguity ("not all sections required") allowed brains to omit it. This change makes the requirement unambiguous and should improve the pass rate from 0% toward 100%.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*