### PR TITLE
docs: deprecate PENDING_ISSUES.md, submit_feedback is sole reporting route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,21 +311,18 @@ When `HEARTBEAT.md` becomes empty, delete the file.
 
 ### Reporting Issues
 
-Two routes exist for surfacing platform/base-brain problems — pick by what the
-user actually wants, not just by trigger phrase:
+When a user explicitly asks to report an issue about the platform or base
+brain (e.g., "zapiš jako issue", "report this", "pošli jako issue"), or when
+you observe a platform problem worth tracking yourself, use
+`mcp__teamvibe-api__submit_feedback`. It writes directly to the central
+feedback DB; consolidated by the eval pipeline into a weekly digest and
+triaged into individual GitHub issues. This is the only supported route —
+most agents don't have GitHub repo access to create issues directly.
 
-**Default: `mcp__teamvibe-api__submit_feedback`** — use for general bug/
-improvement/observation signals ("tohle nefunguje", "warto by bylo...", or
-you noticing a repeated platform problem yourself). Writes directly to the
-central feedback DB; consolidated by the eval pipeline into a weekly digest,
-then triaged into individual GitHub issues later.
-
-**`PENDING_ISSUES.md`: only when the user explicitly wants a dedicated,
-numbered GitHub issue tracked immediately** (not batched into a weekly
-digest) — e.g. "zapiš tohle jako issue na poller-brain, chci to sledovat".
-Valid target repos: `teamvibeai/teamvibe.ai`, `teamvibeai/poller-brain`,
-`teamvibeai/poller-brain-eval`. Included in your next maintenance report and
-turned into a GitHub issue within one cycle. See MAINTENANCE.md for the full
-convention.
-
-If genuinely unsure which the user wants, ask — don't guess from phrasing alone.
+**Migrating from `PENDING_ISSUES.md`:** that file/route is deprecated (agents
+generally lack the GitHub access it implicitly assumed). If your brain still
+has a `PENDING_ISSUES.md` with `status: pending` entries, submit each one via
+`submit_feedback` — infer `type`/`priority` from the entry's content (the old
+format didn't have them), and include the original `repo` in `context` so
+the target isn't lost — then delete the file. See MAINTENANCE.md for the
+one-time migration note.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,10 +319,5 @@ feedback DB; consolidated by the eval pipeline into a weekly digest and
 triaged into individual GitHub issues. This is the only supported route —
 most agents don't have GitHub repo access to create issues directly.
 
-**Migrating from `PENDING_ISSUES.md`:** that file/route is deprecated (agents
-generally lack the GitHub access it implicitly assumed). If your brain still
-has a `PENDING_ISSUES.md` with `status: pending` entries, submit each one via
-`submit_feedback` — infer `type`/`priority` from the entry's content (the old
-format didn't have them), and include the original `repo` in `context` so
-the target isn't lost — then delete the file. See MAINTENANCE.md for the
-one-time migration note.
+`PENDING_ISSUES.md` is deprecated. If your brain still has one, see
+MAINTENANCE.md's "Pending Issues" / "One-Time" sections for the migration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,4 +310,22 @@ When `HEARTBEAT.md` becomes empty, delete the file.
 **Heartbeat reliability:** intervals are variable / best-effort. Never depend on heartbeat for time-critical work — always use scheduled messages.
 
 ### Reporting Issues
-When a user explicitly asks to report an issue about the platform or base brain (e.g., "zapiš jako issue", "report this", "pošli jako issue"), write it to `PENDING_ISSUES.md`. The issue will be included in your next maintenance report and processed into a GitHub issue. See MAINTENANCE.md for the full convention.
+
+Two routes exist for surfacing platform/base-brain problems — pick by what the
+user actually wants, not just by trigger phrase:
+
+**Default: `mcp__teamvibe-api__submit_feedback`** — use for general bug/
+improvement/observation signals ("tohle nefunguje", "warto by bylo...", or
+you noticing a repeated platform problem yourself). Writes directly to the
+central feedback DB; consolidated by the eval pipeline into a weekly digest,
+then triaged into individual GitHub issues later.
+
+**`PENDING_ISSUES.md`: only when the user explicitly wants a dedicated,
+numbered GitHub issue tracked immediately** (not batched into a weekly
+digest) — e.g. "zapiš tohle jako issue na poller-brain, chci to sledovat".
+Valid target repos: `teamvibeai/teamvibe.ai`, `teamvibeai/poller-brain`,
+`teamvibeai/poller-brain-eval`. Included in your next maintenance report and
+turned into a GitHub issue within one cycle. See MAINTENANCE.md for the full
+convention.
+
+If genuinely unsure which the user wants, ask — don't guess from phrasing alone.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -98,15 +98,6 @@ The JSON file is written at the same time as the markdown report, in the same co
     "[proposal] Concrete change proposal with rationale",
     "[blocked] Things I cannot fix myself — need base-brain change or admin input"
   ],
-  "pendingIssues": [
-    {
-      "repo": "teamvibeai/poller-brain",
-      "title": "Short issue title",
-      "context": "What the user described and why it matters",
-      "reportedBy": "@UserName",
-      "date": "2026-04-26"
-    }
-  ],
   "heartbeatStatus": {
     "present": false,
     "nonEmpty": false,
@@ -128,7 +119,6 @@ The JSON file is written at the same time as the markdown report, in the same co
 | `recommendations` | `string[]` | Actionable recommendations for the next maintenance cycle (used by `actionable-recommendations` criterion). **Imperative, one sentence per item. Include success criterion inline when required (see `verifiable-recommendations`). Cap at 5 items.** |
 | `selfAssessment` | `object` | Boolean pass/fail per eval criterion (see Eval Criteria below) |
 | `processImprovements` | `string[]` | Self-critique and proposals for process improvement. Each entry must be prefixed with `[self-critique]`, `[proposal]`, or `[blocked]`. At least one entry required per reflection. **One sentence per item after the prefix. Cap at 5 items.** |
-| `pendingIssues` | `object[]` | Issues reported by users for creation on GitHub. Each object: `repo` (target repository), `title`, `context` (user's description), `reportedBy` (who reported), `date`. Empty array or omitted if none. See Pending Issues section below. |
 | `heartbeatStatus` | `object` | Self-reported state of the brain's `HEARTBEAT.md` file at consolidation time. `present` (bool): file exists. `nonEmpty` (bool): file contains at least one line that is not blank, a heading, an HTML comment, or a completed `- [x]` task. `itemCount` (int): number of unchecked task lines (`- [ ]`). Used by eval pipeline to track heartbeat deprecation progress (`teamvibeai/teamvibe.ai#102`). |
 | `brainCommitSha` | `string` | Output of `git rev-parse HEAD` at the time of the report |
 
@@ -186,40 +176,17 @@ These criteria are used for self-assessment in the JSON report's `selfAssessment
 | `verifiable-recommendations` | Did reflection include at least one recommendation with a stated success criterion? | At least one entry in recommendations specifies: (1) a concrete change to make, (2) the current problem it addresses, AND (3) a verifiable condition that would confirm the recommendation was implemented and effective in a future maintenance cycle |
 | `deletion-with-preservation-evidence` | Did reflection explicitly account for each deleted file's content preservation? | For every file deletion recorded in filesChanged (operationCounts.deleted > 0): the report names in decisions or observations the specific destination file where the deleted content was preserved, OR explicitly states the content was redundant with a specifically named existing file. If operationCounts.deleted is 0, the criterion passes automatically. |
 
-## Pending Issues
+## Pending Issues (deprecated)
 
-Users can ask you to report issues about the platform or base brain. When a user explicitly asks to report an issue (e.g., "zapiš jako issue", "report this as issue", "pošli tohle jako issue"), follow this flow:
-
-### During regular sessions
-
-1. Write the issue to `PENDING_ISSUES.md` in your brain root:
-   ```yaml
-   - repo: teamvibeai/poller-brain
-     title: Short description of the issue
-     context: What the user described and why it matters
-     reportedBy: "@UserName"
-     date: 2026-04-26
-     status: pending
-   ```
-2. Confirm to the user: :memo: + _"Zapsáno jako issue pro `{repo}`. Odešle se v příštím maintenance reportu."_
-
-### During maintenance
-
-3. Read `PENDING_ISSUES.md`. For each entry with `status: pending`:
-   - Include it in the JSON report's `pendingIssues` array
-   - Change status to `reported`
-4. On the next maintenance cycle, delete entries with `status: reported`.
-
-### Rules
-
-- **Only explicit requests** — react only when the user explicitly asks to report/file an issue. Do NOT auto-detect complaints or problems as issues.
-- **Agent formulates the issue** — extract a clear title and context from what the user described. Don't just copy their message verbatim.
-- **Valid repos** — only use repositories the platform knows about: `teamvibeai/teamvibe.ai`, `teamvibeai/poller-brain`, `teamvibeai/poller-brain-eval`.
-- If `PENDING_ISSUES.md` doesn't exist, create it with a `## Pending Issues` header.
+`PENDING_ISSUES.md` is deprecated in favor of `mcp__teamvibe-api__submit_feedback`
+(see CLAUDE.md's "Reporting Issues" section) — most agents don't have GitHub
+repo access to create issues, which the old file-based flow implicitly
+assumed. Do not write new entries to `PENDING_ISSUES.md`.
 
 ## One-Time
 
 - **Memory migration**: If `memory/core/` directory does not exist, run the migration described in the `memory` skill. This splits the old monolithic MEMORY.md into the tiered structure. Only needed once per brain.
+- **`PENDING_ISSUES.md` migration**: If this file exists with `status: pending` entries, submit each one via `mcp__teamvibe-api__submit_feedback` — infer `type`/`priority` from the entry's content (the old format didn't have them) and include the original `repo` in `context` — then delete the file. Only needed once per brain.
 
 ## Daily
 

--- a/skills/teamvibe-api/skill.md
+++ b/skills/teamvibe-api/skill.md
@@ -194,9 +194,16 @@ Submit feedback about the platform. Stored in a central database and consolidate
 
 ### When to use
 
-- User explicitly reports an issue ("report this", "zapiš jako issue", "tohle nefunguje")
-- You observe a platform problem worth tracking (repeated MCP failures, missing features)
+- Default route for platform feedback: general bug/improvement/observation
+  signals, including "report this" / "zapiš jako issue" when the user hasn't
+  asked for a dedicated numbered issue right away
+- You observe a platform problem worth tracking (repeated MCP failures,
+  missing features)
 - You want to suggest an improvement based on your experience
+
+Note: if the user explicitly wants a dedicated numbered GitHub issue tracked
+immediately (not batched into a weekly digest), use `PENDING_ISSUES.md`
+instead — see CLAUDE.md's Reporting Issues section.
 
 ### Example
 

--- a/skills/teamvibe-api/skill.md
+++ b/skills/teamvibe-api/skill.md
@@ -194,16 +194,14 @@ Submit feedback about the platform. Stored in a central database and consolidate
 
 ### When to use
 
-- Default route for platform feedback: general bug/improvement/observation
-  signals, including "report this" / "zapiš jako issue" when the user hasn't
-  asked for a dedicated numbered issue right away
-- You observe a platform problem worth tracking (repeated MCP failures,
-  missing features)
+- User explicitly reports an issue ("report this", "zapiš jako issue", "tohle nefunguje")
+- You observe a platform problem worth tracking (repeated MCP failures, missing features)
 - You want to suggest an improvement based on your experience
 
-Note: if the user explicitly wants a dedicated numbered GitHub issue tracked
-immediately (not batched into a weekly digest), use `PENDING_ISSUES.md`
-instead — see CLAUDE.md's Reporting Issues section.
+This is the platform's only supported feedback/issue-reporting route — most
+agents don't have GitHub repo access to create issues directly.
+`PENDING_ISSUES.md` is deprecated; see CLAUDE.md's Reporting Issues section
+for the one-time migration note.
 
 ### Example
 


### PR DESCRIPTION
Fixes #255.

## Scope (updated per Jakub, 2026-07-31)
Original scope was disambiguating two overlapping routes. Jakub then directed full deprecation of `PENDING_ISSUES.md`: normal agents lack GitHub repo access, so its promise of becoming a numbered issue implicitly assumed credentials most brains don't have. `submit_feedback` is the only universally available route.

## Change (docs-only, 3 files)
- `CLAUDE.md`: "Reporting Issues" now describes only `submit_feedback`, with a migration note for brains that still have a `PENDING_ISSUES.md`.
- `skills/teamvibe-api/skill.md`: `submit_feedback` "When to use" restored to single-route guidance, cross-references CLAUDE.md for the deprecation note.
- `MAINTENANCE.md`: "Pending Issues" flow replaced with a deprecation stub; one-time migration step added (mirrors the existing HEARTBEAT.md pattern). Removed the now-orphaned `pendingIssues` JSON schema field/example — no eval criterion ever consumed it (unlike `heartbeatStatus`, which backs `teamvibeai/teamvibe.ai#102` tracking).

## Review
Two rounds of DevGuru ack in Slack (channel C0BJFTSCAP4, 2026-07-31):
1. Initial disambiguation diff (2 files) — acked, PR opened.
2. Re-scoped full-deprecation diff (3 files, verbatim patch reviewed) — acked, with two non-blocking suggestions incorporated in the final commit: migration note now says to infer `type`/`priority` (old entries never had them) and preserve the original `repo` in `context`.

Tier 2 (fleet-wide visible behavior change) — merge held for @jakubknejzlik.