### PR TITLE
fix(consolidate): add post-write existence check for consolidation report

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -531,6 +531,8 @@ Create both a markdown and JSON report:
 - **Markdown:** `reports/YYYY-MM-DD-memory-consolidation.md` (must include `## Daily Log Compliance` from Step 10, `## MEM Audit` from Step 9a, and `## Memory Metrics` from Step 9b)
 - **JSON:** `reports/YYYY-MM-DD-memory-consolidation.json` (must include `daily-log-*` and `mem-integrity-check` keys in `selfAssessment`, and the `[self-critique]` entry from Step 11 in `processImprovements`)
 
+**Post-write existence check (required, added per pb#257):** After writing the JSON report, run `ls reports/YYYY-MM-DD-memory-consolidation.json` and confirm it exists on disk. This step is easy to drop silently on unusually busy sessions (many interleaved threads) — and when it's dropped, the poller's guard-file hook (`teamvibe.ai#128`) has nothing to POST, so `.last_consolidation` never updates even though real consolidation content landed. The next `maintenance-guard.sh` run then reports a false-overdue signal despite consolidation having actually happened. Do not end the session (final commit made, TODAY.md archived) without this file present — if the check fails, stop and produce the report now rather than closing the session first.
+
 For `selfAssessment.reduce-log-count`: set to `true` if at least one daily log was actively processed this run — either (a) Step 7 deleted one or more log files, OR (b) Steps 2–4 extracted content from at least one log and produced at least one ADD or UPDATE action. Set to `false` if no logs were processed (e.g., no logs in range, all NOOP). **Always include daily log files whose content was extracted in `filesChanged`**, even if they were not deleted — listing source logs gives the evaluator the evidence of log file activity it needs to verify this criterion.
 
 ## Scoring Guidance
@@ -542,6 +544,8 @@ When deciding what to promote, weigh:
 - **Impact** — does this affect how you should behave in future sessions?
 
 ## Commit
+
+Before committing, confirm both `reports/YYYY-MM-DD-memory-consolidation.md` and `.json` exist on disk (`ls reports/YYYY-MM-DD-memory-consolidation.*`) — see Step 12's post-write existence check.
 
 After consolidation, commit all changes (including reports):
 ```


### PR DESCRIPTION
## Problem

`pb#257`: Step 12 (Produce Report) of the consolidate skill is the last step of the session and can silently get dropped on unusually busy sessions (many interleaved threads). When it's dropped, the poller's guard-file hook (`teamvibe.ai#128`) never fires — it only writes `.last_consolidation` after successfully POSTing a `reports/*.json` file with `operationType: "consolidation"`. With no report, `maintenance-guard.sh` reports a false-overdue signal on the next run, even though real consolidation content landed.

Confirmed on VibeKeeper's own brain 2026-08-01: consolidation content work landed both 07-30 and 07-31, but neither session produced a `reports/*.json` pair, so `.last_consolidation` stayed stuck at 07-29.

## Fix

Adds a deterministic post-write existence check to Step 12: after writing `reports/YYYY-MM-DD-memory-consolidation.json`, run `ls` and confirm it exists before the session can be considered complete. Also adds a pre-commit reminder in the Commit section.

This mirrors the existing pattern for `.last_consolidation` (moved out of LLM-skill control into a deterministic, success-gated hook per #109/#112) — same idea, applied one step earlier so the report itself doesn't get silently skipped in the first place.

## Scope

Small, additive doc-only change (+4 lines) to `skills/memory/consolidate/skill.md`. No behavior change for sessions that already produce the report correctly.

Closes teamvibeai/poller-brain#257

---
*Od tebe potřebuju:* DevGuru review/ack (base-brain `skills/memory/*` change, MEM-35 blast-radius gate), then Jakub merge. Tagging <@U01TALN63DK> for visibility — see morning report for full context.
