### PR TITLE
feat(mcp/slack): add get_permalink tool

### DIFF
--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -578,6 +578,17 @@ const TOOLS = [
     },
   },
   {
+    name: 'get_permalink',
+    description: 'Get a clickable Slack permalink URL for a specific message. Use this instead of guessing the workspace subdomain or hand-building an archives/deep-link URL.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        channel: { type: 'string', description: 'Channel ID (default: current channel)' },
+        message_ts: { type: 'string', description: 'Timestamp of the message to link to (default: current thread timestamp, or original message timestamp if not in a thread)' },
+      },
+    },
+  },
+  {
     name: 'list_thread_participants',
     description: 'List participants in the current thread: user IDs, display names, bot/human flags, and self marker. Use to know "who is in the room" before deciding tags, handoffs, or escalations. Returns deduplicated participants in first-spoke order.',
     inputSchema: {
@@ -877,6 +888,15 @@ async function handleTool(name, args) {
         }),
       }))
       return { ok: true, messages }
+    }
+
+    case 'get_permalink': {
+      const channel = args.channel || DEFAULT_CHANNEL
+      const message_ts = args.message_ts || DEFAULT_THREAD_TS || DEFAULT_MESSAGE_TS
+      if (!channel) throw new Error('channel required')
+      if (!message_ts) throw new Error('message_ts required')
+      const result = await slackApi('chat.getPermalink', { channel, message_ts })
+      return { ok: true, permalink: result.permalink }
     }
 
     case 'list_thread_participants': {


### PR DESCRIPTION
Closes #263.

Adds a `get_permalink` tool to `mcp/slack.mjs` wrapping Slack's `chat.getPermalink` API, so agents can produce correct clickable links to prior messages/threads without guessing the workspace subdomain or hand-building deep links.

**Corrected scope note:** this was originally tracked as teamvibeai/teamvibe.ai#269, which mis-scoped the fix to `packages/poller/src/slack-client.ts` (assuming a `packages/poller` platform-code change + `poller-v*` publish). That file is a small internal client used by the poller process itself, not the agent-facing MCP server. The actual runtime implementation of `mcp__slack__*` tools is this repo's `mcp/slack.mjs`. tv#269 closed as wrong-repo; #263 is the corrected tracking issue.

**Changes (+20/-0, mcp/slack.mjs only):**
- New `get_permalink` tool definition (schema: optional `channel`, `message_ts`)
- Handler wraps `slackApi("chat.getPermalink", { channel, message_ts })`, follows the exact same shape as sibling read-only wrappers (`read_channel_info`, `add_reaction`) — same default-fallback pattern, same JSON-POST path.

**Testing:** full existing `mcp/__tests__/*.test.mjs` suite (135 tests) passes unmodified against the edited file, no regressions. No new test added — none of the other simple pass-through wrappers (`add_reaction`, `read_channel_info`, etc.) have dedicated tests either, consistent with existing convention.

**Review:** DevGuru ack given pre-commit (diff outline + acceptance criteria posted and acked in Slack thread, per MEM-29/157/189 ordering rule).

**Do not merge yet** — holding per explicit instruction, awaiting Jakub's go.