### PR TITLE
fix(slack): auto-repair bare URL wrapped in *...* bold (linkify break)

### DIFF
--- a/mcp/__tests__/slack-convert.test.mjs
+++ b/mcp/__tests__/slack-convert.test.mjs
@@ -9,9 +9,9 @@ import { dirname, join } from 'node:path'
 
 const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'slack.mjs'), 'utf8')
 const prelude = src.split('// --- stdio transport ---')[0]
-const exports = '\nexport { isTableLine, computePipeTableWarning, gfmInlineToMrkdwn, convertPipeTablesToBlocks, textToSections }\n'
+const exports = '\nexport { isTableLine, computePipeTableWarning, gfmInlineToMrkdwn, convertPipeTablesToBlocks, textToSections, stripBoldWrappedUrl }\n'
 const mod = await import('data:text/javascript,' + encodeURIComponent(prelude + exports))
-const { computePipeTableWarning, convertPipeTablesToBlocks } = mod
+const { computePipeTableWarning, convertPipeTablesToBlocks, stripBoldWrappedUrl } = mod
 
 let pass = 0, fail = 0
 const ok = (n, c) => { if (c) { pass++; console.log('  ✓', n) } else { fail++; console.log('  ✗ FAIL', n) } }
@@ -69,6 +69,32 @@ const ok = (n, c) => { if (c) { pass++; console.log('  ✓', n) } else { fail++;
 // 9) single isolated pipe line (not 2+ rows) → not a table
 {
   ok('9 lone pipe line not a table', computePipeTableWarning('cena | 100 Kč jeden řádek') === null)
+}
+
+// 10) poller-brain#225: bare URL wrapped as its own bold span -> stripped
+{
+  ok('10 whole-span bold URL stripped', stripBoldWrappedUrl('*https://x.io/a*') === 'https://x.io/a')
+  ok('10 mid-sentence, surrounded by other text', stripBoldWrappedUrl('Hotovo: *https://x.io/a* diky') === 'Hotovo: https://x.io/a diky')
+  ok('10 start of string, trailing text', stripBoldWrappedUrl('*https://x.io/a* diky') === 'https://x.io/a diky')
+  ok('10 end of string, leading text', stripBoldWrappedUrl('Viz *https://x.io/a*') === 'Viz https://x.io/a')
+  ok('10 multiple occurrences', stripBoldWrappedUrl('*https://a.io*\n*https://b.io*') === 'https://a.io\nhttps://b.io')
+}
+// 11) poller-brain#225: NOT touched — bold sentence merely containing a URL as substring
+{
+  const t = '*Viz report: https://x.io/a pro detaily*'
+  ok('11 bold sentence with URL substring untouched', stripBoldWrappedUrl(t) === t)
+}
+// 12) poller-brain#225: NOT touched — other markers (narrow scope: only `*...*`)
+{
+  ok('12 underscore-italic untouched', stripBoldWrappedUrl('_https://x.io/a_') === '_https://x.io/a_')
+  ok('12 tilde-strike untouched', stripBoldWrappedUrl('~https://x.io/a~') === '~https://x.io/a~')
+  ok('12 double-star GFM bold untouched (different pattern)', stripBoldWrappedUrl('**https://x.io/a**') === '**https://x.io/a**')
+}
+// 13) poller-brain#225: plain text / no markers -> byte-identical passthrough
+{
+  const t = 'Jen normální text s https://x.io/a bez formátování.'
+  ok('13 unwrapped URL untouched', stripBoldWrappedUrl(t) === t)
+  ok('13 no URL at all untouched', stripBoldWrappedUrl('*tučně* bez URL') === '*tučně* bez URL')
 }
 
 console.log(`\n${pass} passed, ${fail} failed`)

--- a/mcp/__tests__/slack-payload.test.mjs
+++ b/mcp/__tests__/slack-payload.test.mjs
@@ -83,6 +83,33 @@ const TABLE = '| úkol | stav |\n|---|---|\n| deploy | ✅ |'
   ok('e agent blocks+table text → passthrough (no double render path)', r.transformed === null)
 }
 
+// (g) poller-brain#225: bold-wrapped bare URL in text -> stripped + echoed,
+// applies even when no table is present (the plain-passthrough case the bug
+// actually reproduces in)
+{
+  const r = buildSendPayload({ text: 'Report: *https://x.io/a* hotovo' })
+  ok('g effectiveText has asterisks stripped', r.effectiveText === 'Report: https://x.io/a hotovo')
+  ok('g no blocks synthesized (still plain passthrough)', r.blocks.length === 0)
+  ok('g transformed echoes the fix', r.transformed?.reason === 'bold_wrapped_url_in_text' && r.transformed.bold_url_stripped === true)
+}
+
+// (h) #225 fix still applies even when the agent supplies its own blocks —
+// `text` still reaches Slack (section-prepended), so the same bug would hit it
+{
+  const own = [{ type: 'divider' }]
+  const r = buildSendPayload({ text: '*https://x.io/a*', blocks: own })
+  ok('h text field fixed even with agent blocks', r.blocks[0].type === 'section' && r.blocks[0].text.text === 'https://x.io/a')
+  ok('h transform still echoed', r.transformed?.bold_url_stripped === true)
+}
+
+// (i) #225 + table combo: both fixes apply, table transform stays primary reason
+{
+  const r = buildSendPayload({ text: `*https://x.io/a*\n\n${TABLE}` })
+  ok('i table transform reason preserved', r.transformed?.reason === 'pipe_table_in_text')
+  ok('i bold_url_stripped flag also present', r.transformed?.bold_url_stripped === true)
+  ok('i prose section carries the stripped URL, no asterisks', r.blocks.find(b => b.type === 'section').text.text.includes('https://x.io/a') && !r.blocks.find(b => b.type === 'section').text.text.includes('*https'))
+}
+
 // (f) buildSendResponse key order — the poller truncates a logged tool_result at
 // 200 chars, so a code that lands after unbounded prose is invisible to whoever
 // counts warnings in the session log (#108 counting, #184 phase 3).

--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -444,6 +444,23 @@ function buildSendResponse({ ts, transformed, warnings }) {
   return response
 }
 
+// Repairs a bare URL wrapped in single-asterisk bold where the ENTIRE bold
+// span is just the URL (poller-brain#225). Root cause (empirically confirmed
+// against live Slack rendering): Slack's autolinker finds the `http(s)://`
+// start fine, so the leading `*` is stranded as literal text, but it scans
+// forward for the URL's end until whitespace — `*` isn't a stop character, so
+// the trailing `*` gets swallowed into the href and corrupts it. A bare URL
+// (no adjacent markers) already renders correctly, so stripping both
+// asterisks is sufficient — no need to re-wrap as an explicit `<url>` link.
+// Deliberately narrow: only the `*...*` marker (not `_..._`/`~...~`), and only
+// when the bold span contains NOTHING but the URL — a bold sentence that
+// merely mentions a URL (`*see https://x for details*`) is untouched, since
+// there's no evidence that pattern hits the same adjacency bug and it's a far
+// more common, riskier span to alter.
+function stripBoldWrappedUrl(text) {
+  return text.replace(/(^|\s)\*(https?:\/\/[^\s*]+)\*(?=\s|$)/g, '$1$2')
+}
+
 // Pure payload builder for send_message: decides final blocks / effective text /
 // transform echo BEFORE any network I/O, so the three-way branch (auto-convert
 // vs section-prepend vs verbatim passthrough) is unit-testable without Slack.
@@ -453,24 +470,39 @@ function buildSendResponse({ ts, transformed, warnings }) {
 // table, opt-out/passthrough keeps the #224 warning). No behavior change vs the
 // prior inline logic — this is an extraction to lock the branches regressibly.
 function buildSendPayload(args, { hasModals = false } = {}) {
+  // #225 fix runs first and unconditionally on `text` (not gated behind the
+  // agentSuppliedBlocks opt-out like the table converter): even when the agent
+  // supplies its own blocks, `text` is still sent — either prepended as a
+  // section or as the notification fallback — so the same rendering bug would
+  // reach Slack either way.
+  const rawText = args.text
+  const text = typeof rawText === 'string' ? stripBoldWrappedUrl(rawText) : rawText
+  const boldUrlFixed = text !== rawText
+
   const agentBlocks = args.blocks ? [...args.blocks] : []
   const agentSuppliedBlocks = agentBlocks.length > 0
-  const tableWarning = computePipeTableWarning(args.text)
+  const tableWarning = computePipeTableWarning(text)
 
   let blocks = agentBlocks
-  let effectiveText = args.text
+  let effectiveText = text
   let transformed = null
 
   const converted =
-    args.text?.trim() && tableWarning && !agentSuppliedBlocks
-      ? convertPipeTablesToBlocks(args.text)
+    text?.trim() && tableWarning && !agentSuppliedBlocks
+      ? convertPipeTablesToBlocks(text)
       : null
   if (converted) {
     blocks = converted.blocks
     effectiveText = converted.fallbackText
     transformed = converted.transformed
-  } else if (args.text?.trim() && (agentSuppliedBlocks || hasModals)) {
-    blocks = [...textToSections(args.text), ...agentBlocks]
+  } else if (text?.trim() && (agentSuppliedBlocks || hasModals)) {
+    blocks = [...textToSections(text), ...agentBlocks]
+  }
+
+  if (boldUrlFixed) {
+    transformed = transformed
+      ? { ...transformed, bold_url_stripped: true }
+      : { reason: 'bold_wrapped_url_in_text', bold_url_stripped: true }
   }
 
   return { blocks, effectiveText, transformed, tableWarning, agentSuppliedBlocks }
@@ -507,7 +539,7 @@ const TOOLS = [
     inputSchema: {
       type: 'object',
       properties: {
-        text: { type: 'string', description: 'Message text (supports Slack markdown: *bold*, _italic_, `code`, ```code blocks```, > quotes). AUTO-CONVERT: if this contains a GFM pipe-table and you provide NO `blocks`, the table is automatically moved into a `markdown` block (which renders columns) and this field becomes a plain-text notification fallback — the response echoes what changed under `transformed`. To opt out and control layout yourself, supply your own `blocks`. When you DO provide `blocks`, this text is prepended as a visible section block AND used as the notification/accessibility fallback.' },
+        text: { type: 'string', description: 'Message text (supports Slack markdown: *bold*, _italic_, `code`, ```code blocks```, > quotes). AUTO-CONVERT: if this contains a GFM pipe-table and you provide NO `blocks`, the table is automatically moved into a `markdown` block (which renders columns) and this field becomes a plain-text notification fallback — the response echoes what changed under `transformed`. To opt out and control layout yourself, supply your own `blocks`. When you DO provide `blocks`, this text is prepended as a visible section block AND used as the notification/accessibility fallback. AUTO-REPAIR: a bare URL wrapped in bold as its own span (`*https://...*`) is auto-stripped to a plain URL — Slack mangles that pattern\'s link (see `transformed.bold_url_stripped`). Prefer a bare URL or `<url|label>` yourself rather than relying on this.' },
         blocks: { type: 'array', description: 'Optional Block Kit blocks array (e.g. sections, actions, or a `markdown` block for tables/GFM). See https://api.slack.com/block-kit. Providing blocks OPTS OUT of table auto-convert — your blocks are sent as-is and `text` is prepended as a visible section block. Omit blocks to let a GFM table in `text` auto-convert.', items: { type: 'object' } },
         channel: { type: 'string', description: 'Channel ID (default: current channel)' },
         thread_ts: { type: ['string', 'null'], description: 'Thread timestamp (default: current thread). Pass null to send a top-level channel message even when in a thread session.' },


### PR DESCRIPTION
## Problem

Closes #225. A bare URL wrapped in single-asterisk bold (`*https://x*`) does not linkify cleanly in Slack.

**Empirically confirmed live rendering** (thread: internal analysis with Marosh, DevGuru ack): Slack finds the `http(s)://` start fine so the leading `*` is stranded as literal text, but scans forward for the URL end until whitespace -- `*` isn't a stop character, so the trailing `*` gets swallowed into the href and corrupts the link. A bare URL (no adjacent markers) already renders correctly.

## Fix

`stripBoldWrappedUrl()` -- a new always-run pass in `buildSendPayload`, independent of the table-auto-convert branch (the repro has no table) and applied regardless of whether the agent supplies its own `blocks` (the `text` field is still sent either way, so the bug reaches Slack via that path too).

Deliberately narrow scope (agreed in triage):
- Only the `*...*` marker (not `_..._`/`~~~~`), no evidence those break the same way.
- Only when the entire bold span is nothing but the URL -- a bold sentence that merely mentions a URL (`*see https://x for details*`) is left untouched (common pattern, no evidence of the same bug, would visibly change bold text fleet-wide).
- Strip only, no `<url>` wrap -- confirmed adjacency-specific, so a bare URL already renders identically to the fix's end state.

`transformed.bold_url_stripped: true` echoes the change back to the caller (composes with the existing table `transformed.reason` without changing it, see test `i`).

## Known non-blocking limitation (DevGuru review)

The closing lookahead (`(?=\s|$)`) doesn't catch a URL immediately followed by punctuation (`*https://x*.` with a trailing period) -- out of scope for the reported bug, noted for a future feedback item if it comes up.

## Tests

5 new direct unit tests (`slack-convert.test.mjs`) + 3 integration tests via `buildSendPayload` (`slack-payload.test.mjs`, including the table+URL combo). Full suite (154 assertions, 6 files) green, `node --check` clean.

## Review

DevGuru ack'd (reviewed actual diff in a fresh clone, not just this description).

Tier-2 (base-brain send path) -- needs Jakub merge decision, not self-merging.

🤖 Generated with VibeKeeper