### PR TITLE
fix(memory): mem-write.ts never received the log-write.ts stale-header rollover fix

### DIFF
--- a/skills/memory/scripts/lib/today-md-core.ts
+++ b/skills/memory/scripts/lib/today-md-core.ts
@@ -1,12 +1,16 @@
 /**
- * Pure date-rollover decision logic for log-write.ts.
+ * Pure date-rollover decision logic for memory/TODAY.md, shared by
+ * log-write.ts and mem-write.ts (both write to TODAY.md and must agree on
+ * when a UTC day boundary requires a fresh "# YYYY-MM-DD" section).
  *
- * Extracted so the day-boundary branch (new day -> fresh "# YYYY-MM-DD"
- * section) can be fixture-tested without touching a real brain's TODAY.md.
- * Must check the LAST date header, not the first, so a same-day call after
- * an earlier rollover does not append a duplicate section.
+ * Extracted so the day-boundary branch can be fixture-tested without
+ * touching a real brain's TODAY.md. Must check the LAST date header, not the
+ * first, so a same-day call after an earlier rollover does not append a
+ * duplicate section.
  *
- * Reference: poller-brain#184 (DevGuru review of PR#183).
+ * Reference: poller-brain#184 (DevGuru review of PR#183); poller-brain#267
+ * (mem-write.ts never got this fix — module renamed from log-write-core.ts
+ * so its shared nature is obvious from the name).
  */
 
 export type RolloverAction =

--- a/skills/memory/scripts/log-write.test.ts
+++ b/skills/memory/scripts/log-write.test.ts
@@ -11,7 +11,7 @@
  * Exits non-zero on the first failed assertion.
  */
 
-import { computeRollover } from "./lib/log-write-core.js";
+import { computeRollover } from "./lib/today-md-core.js";
 
 let passed = 0;
 function assert(cond: boolean, msg: string): void {

--- a/skills/memory/scripts/log-write.ts
+++ b/skills/memory/scripts/log-write.ts
@@ -15,13 +15,13 @@
 
 import * as fs from "fs";
 import { brainPath } from "./lib/brain-root.js";
-import { computeRollover } from "./lib/log-write-core.js";
+import { computeRollover } from "./lib/today-md-core.js";
 
 const TODAY_PATH = brainPath("memory/TODAY.md");
 
-// Rollover decision lives in lib/log-write-core.ts (fixture-tested — see
+// Rollover decision lives in lib/today-md-core.ts (fixture-tested — see
 // log-write.test.ts) so the day-boundary branch can't silently regress
-// (poller-brain#184).
+// (poller-brain#184). Shared with mem-write.ts (poller-brain#267).
 function ensureToday(): void {
   const today = new Date().toISOString().slice(0, 10);
   const existingContent = fs.existsSync(TODAY_PATH)

--- a/skills/memory/scripts/mem-write.test.ts
+++ b/skills/memory/scripts/mem-write.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { getNextKeyFromContents } from "./lib/mem-write-core.js";
+import { computeRollover } from "./lib/today-md-core.js";
 
 let passed = 0;
 function assert(cond: boolean, msg: string): void {
@@ -88,6 +89,29 @@ function assert(cond: boolean, msg: string): void {
 {
   const key = getNextKeyFromContents("", "", "");
   assert(key === 1, `fresh brain must start at key 1, got ${key}`);
+}
+
+// --- mem-write.ts must roll over a stale TODAY.md header too (poller-brain#267:
+// mem-write.ts historically only handled the file-missing case, never the
+// stale-header case that log-write.ts already covers via the same function) --
+{
+  const content = "# 2026-07-28\n\n- [MEM-3] deploy: staging vyžaduje SSO login\n";
+  const action = computeRollover(content, "2026-07-29");
+  assert(
+    action.kind === "append-header",
+    "mem-write.ts's ensureToday must roll a stale header on a new UTC day"
+  );
+  assert(
+    action.textToWrite === "\n# 2026-07-29\n\n",
+    "rollover must append a fresh dated section, not rewrite history"
+  );
+}
+
+// --- same-day mem-write.ts call must not duplicate the header --------------
+{
+  const content = "# 2026-07-29\n\n- [MEM-3] deploy: staging vyžaduje SSO login\n";
+  const action = computeRollover(content, "2026-07-29");
+  assert(action.kind === "none", "same-day mem-write.ts call must be a no-op");
 }
 
 console.log(`✅ all ${passed} assertions passed`);

--- a/skills/memory/scripts/mem-write.ts
+++ b/skills/memory/scripts/mem-write.ts
@@ -17,6 +17,7 @@
 import * as fs from "fs";
 import { brainPath } from "./lib/brain-root.js";
 import { getNextKeyFromContents } from "./lib/mem-write-core.js";
+import { computeRollover } from "./lib/today-md-core.js";
 
 const REGISTRY_PATH = brainPath("memory/MEM_REGISTRY.md");
 const ARCHIVE_PATH = brainPath("memory/MEM_REGISTRY_ARCHIVE.md");
@@ -49,10 +50,21 @@ function ensureRegistry(): void {
   }
 }
 
+// Rollover decision lives in lib/today-md-core.ts (fixture-tested — see
+// mem-write.test.ts) so a stale TODAY.md header isn't left in place when
+// mem-write.ts is the first write of a new UTC day (poller-brain#267 —
+// log-write.ts got this fix in cffb04c/e2f5420, mem-write.ts never did).
 function ensureToday(): void {
-  if (!fs.existsSync(TODAY_PATH)) {
-    const today = new Date().toISOString().slice(0, 10);
-    fs.writeFileSync(TODAY_PATH, `# ${today}\n\n`);
+  const today = new Date().toISOString().slice(0, 10);
+  const existingContent = fs.existsSync(TODAY_PATH)
+    ? fs.readFileSync(TODAY_PATH, "utf-8")
+    : null;
+  const action = computeRollover(existingContent, today);
+
+  if (action.kind === "create") {
+    fs.writeFileSync(TODAY_PATH, action.textToWrite);
+  } else if (action.kind === "append-header") {
+    fs.appendFileSync(TODAY_PATH, action.textToWrite);
   }
 }
 


### PR DESCRIPTION
## Summary

`mem-write.ts`'s `ensureToday()` only handled the "TODAY.md doesn't exist" case. If TODAY.md already existed with a stale date header, `mem-write.ts` appended the new `[MEM-N]` entry under the wrong date instead of rolling over — the exact misfiled-entry pattern that `log-write.ts` was fixed for in `cffb04c`/`e2f5420`, just via the other write path.

Closes #267.

## Changes (variant B, per discussion in C0BJFTSCAP4)

- Renamed `skills/memory/scripts/lib/log-write-core.ts` → `lib/today-md-core.ts` (no logic change — the module is shared by two scripts now, name should reflect that).
- `log-write.ts` / `log-write.test.ts`: import path update only.
- `mem-write.ts`'s `ensureToday()`: now calls `computeRollover` and handles `create`/`append-header`/`none` identically to `log-write.ts` — no partial reimplementation.
- `mem-write.test.ts`: 2 new fixture tests (stale-header rollover, same-day no-op) mirroring `log-write.test.ts`'s day-boundary coverage.

## Verification

- All existing fixture suites pass unmodified: `log-write.test.ts` (6/6), `mem-write.test.ts` (9/9 incl. 2 new), `mem-registry-archive.test.ts` (31/31).
- Live smoke test via `BRAIN_ROOT` against a scratch dir with a stale `# 2020-01-01` header: `mem-write.ts` correctly preserved the old section and appended a fresh dated section for the new entry.
- Live smoke test against a brain with no TODAY.md at all: file-missing case still creates a fresh header identically to pre-change behavior.

## Review

DevGuru-reviewed and ack'd 2026-08-03 in C0BJFTSCAP4 (full diff walked through in 4 parts due to message-length truncation issues).

Draft — merge decision is Jakub's per base-brain Tier-2 convention.
