### PR TITLE
fix(mcp): normalize HTML-escaped mention entities in send_message

### DIFF
--- a/mcp/__tests__/slack-payload.test.mjs
+++ b/mcp/__tests__/slack-payload.test.mjs
@@ -135,5 +135,49 @@ const TABLE = '| úkol | stav |\n|---|---|\n| deploy | ✅ |'
   ok('f both codes survive truncation together', truncate(JSON.stringify(two)).includes('thread_ts_override_unjustified'))
 }
 
+// (j) HTML-entity normalization (poller-brain#243): escaped mention/link
+// syntax is unescaped before any table/block processing sees it, in every
+// branch (verbatim passthrough, section-prepend, and inside a synthesized
+// table's surrounding prose).
+{
+  const r = buildSendPayload({ text: 'ping &lt;@U02C5FJFD6E&gt; re: A &amp; B' })
+  ok('j verbatim passthrough unescaped', r.effectiveText === 'ping <@U02C5FJFD6E> re: A & B')
+}
+{
+  const own = [{ type: 'divider' }]
+  const r = buildSendPayload({ text: 'hi &lt;@U1&gt;', blocks: own })
+  ok('j section-prepend branch unescaped', r.blocks[0].text.text === 'hi <@U1>')
+}
+{
+  // &amp;lt; must decode to literal "&lt;", not cascade into "<"
+  const r = buildSendPayload({ text: 'literal &amp;lt; stays escaped-once' })
+  ok('j &amp; decoded last (no cascade)', r.effectiveText === 'literal &lt; stays escaped-once')
+}
+{
+  // table-auto-convert branch: prose surrounding the table carries the
+  // escaped mention — must be unescaped in the actual `blocks` sent to
+  // Slack (not just effectiveText/fallbackText), since blocks is what
+  // renders once present (DevGuru review, poller-brain#243).
+  const r = buildSendPayload({ text: `ping &lt;@U1&gt; hotovo:\n\n${TABLE}` })
+  const proseBlock = r.blocks.find(b => b.type === 'section')
+  ok('j table-branch prose block unescaped', proseBlock?.text?.text === 'ping <@U1> hotovo:')
+  ok('j table-branch fallbackText unescaped', r.effectiveText.includes('ping <@U1> hotovo:'))
+}
+{
+  // a QUOTED escaped mention inside a fenced code block (a bug report citing
+  // the raw syntax, exactly like this review thread) must stay literal —
+  // decoding it would turn a code example into a real ping (DevGuru review,
+  // poller-brain#243).
+  const r = buildSendPayload({ text: 'see example:\n```\nping &lt;@U1&gt;\n```\nreal ping: &lt;@U2&gt;' })
+  ok('j fenced code block left escaped', r.effectiveText.includes('```\nping &lt;@U1&gt;\n```'))
+  ok('j prose outside fence still unescaped', r.effectiveText.includes('real ping: <@U2>'))
+}
+{
+  // same for a single-backtick inline code span
+  const r = buildSendPayload({ text: 'the literal `&lt;@U1&gt;` syntax vs a real ping &lt;@U2&gt;' })
+  ok('j inline code span left escaped', r.effectiveText.includes('`&lt;@U1&gt;`'))
+  ok('j prose outside inline code still unescaped', r.effectiveText.includes('a real ping <@U2>'))
+}
+
 console.log(`\n${pass} passed, ${fail} failed`)
 if (fail) process.exit(1)

--- a/mcp/slack.mjs
+++ b/mcp/slack.mjs
@@ -359,6 +359,25 @@ function gfmInlineToMrkdwn(text) {
     .replace(/~~([^~]+?)~~/g, '~$1~')
 }
 
+// Undo HTML-entity escaping (&lt;@U..&gt; etc.) agents sometimes produce after
+// reading HTML-escaped context (e.g. thread history), which otherwise renders
+// as literal text instead of a mention/link and silently drops the ping.
+// Safe in one direction only: Slack's `text` field has its own (different)
+// escaping rules and never relies on these HTML sequences meaning anything.
+// Fenced code blocks and inline code spans are left untouched (same fence
+// convention as computePipeTableWarning) — an escaped mention QUOTED as a
+// code example (e.g. a bug report citing `&lt;@U..&gt;`, like this file's own
+// review thread) must not silently become a live ping. A single alternation
+// pass — rather than three sequential .replace() calls — naturally decodes
+// each occurrence once (leftmost match wins), so "&amp;lt;" resolves to the
+// literal "&lt;" instead of cascading into "<". See teamvibeai/poller-brain#243.
+function normalizeHtmlEntities(text) {
+  return text.replace(/(```[\s\S]*?```|`[^`\n]*`)|(&lt;|&gt;|&amp;)/g, (m, code, entity) => {
+    if (code) return code
+    return entity === '&lt;' ? '<' : entity === '&gt;' ? '>' : '&'
+  })
+}
+
 // Auto-convert (teamvibeai/teamvibe.ai#228, Variant B): split `text` into
 // prose + pipe-table segments IN ORDER, render prose as section(mrkdwn) blocks
 // and each table as a raw `markdown` block. Returns { blocks, fallbackText,
@@ -474,10 +493,14 @@ function buildSendPayload(args, { hasModals = false } = {}) {
   // agentSuppliedBlocks opt-out like the table converter): even when the agent
   // supplies its own blocks, `text` is still sent — either prepended as a
   // section or as the notification fallback — so the same rendering bug would
-  // reach Slack either way.
+  // reach Slack either way. HTML-entity normalization (#243) runs before it —
+  // order doesn't matter functionally (disjoint patterns) but boldUrlFixed
+  // below is measured against the entity-normalized text, not raw, so it only
+  // flags actual bold-url stripping.
   const rawText = args.text
-  const text = typeof rawText === 'string' ? stripBoldWrappedUrl(rawText) : rawText
-  const boldUrlFixed = text !== rawText
+  const htmlNormalized = typeof rawText === 'string' ? normalizeHtmlEntities(rawText) : rawText
+  const text = typeof htmlNormalized === 'string' ? stripBoldWrappedUrl(htmlNormalized) : htmlNormalized
+  const boldUrlFixed = text !== htmlNormalized
 
   const agentBlocks = args.blocks ? [...args.blocks] : []
   const agentSuppliedBlocks = agentBlocks.length > 0


### PR DESCRIPTION
Closes #243

Slack thread history and other context sources return `&lt;@U..&gt;` already HTML-escaped. When an agent echoes that syntax back into `send_message` text, it renders as literal text instead of a mention and silently drops the ping.

`buildSendPayload` now normalizes entities in `text` before table/block processing, applied consistently across all three payload branches (verbatim passthrough, section-prepend, table-auto-convert) so `blocks` and `effectiveText` never diverge.

Fenced code blocks and inline code spans are left untouched (same convention as `computePipeTableWarning`), so a quoted example of the escaped syntax in a bug report does not turn into a live ping.

Reviewed by DevGuru (2 rounds — branch-coverage blocker + fence-awareness finding, both resolved and ack'd).

**Test plan**
- [x] 4 new unit tests in `mcp/__tests__/slack-payload.test.mjs` (verbatim, section-prepend, table-branch blocks content, fence/inline-code awareness, no-cascade `&amp;lt;`)
- [x] Full suite green: 35/35 `slack-payload.test.mjs`, 331/331 repo-wide

Stays draft pending merge decision.