### PR TITLE
Auto-improve: update-relevant-tiers

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -528,8 +528,8 @@ Example entries:
 
 Create both a markdown and JSON report:
 
-- **Markdown:** `reports/YYYY-MM-DD-memory-consolidation.md` (must include `## Daily Log Compliance` from Step 10, `## MEM Audit` from Step 9a, and `## Memory Metrics` from Step 9b)
-- **JSON:** `reports/YYYY-MM-DD-memory-consolidation.json` (must include `daily-log-*` and `mem-integrity-check` keys in `selfAssessment`, and the `[self-critique]` entry from Step 11 in `processImprovements`)
+- **Markdown:** `reports/YYYY-MM-DD-memory-consolidation.md` (must include `## Tier Coverage` per MAINTENANCE.md tier coverage check, `## Daily Log Compliance` from Step 10, `## MEM Audit` from Step 9a, and `## Memory Metrics` from Step 9b)
+- **JSON:** `reports/YYYY-MM-DD-memory-consolidation.json` (must include `update-relevant-tiers` in `selfAssessment`, `daily-log-*` and `mem-integrity-check` keys in `selfAssessment`, and the `[self-critique]` entry from Step 11 in `processImprovements`)
 
 For `selfAssessment.reduce-log-count`: set to `true` if at least one daily log was actively processed this run — either (a) Step 7 deleted one or more log files, OR (b) Steps 2–4 extracted content from at least one log and produced at least one ADD or UPDATE action. Set to `false` if no logs were processed (e.g., no logs in range, all NOOP). **Always include daily log files whose content was extracted in `filesChanged`**, even if they were not deleted — listing source logs gives the evaluator the evidence of log file activity it needs to verify this criterion.
 


### PR DESCRIPTION
## Auto-Improvement

> **This PR modifies Tier 2 files (skills/) -- human review required before merge.**

**Target criterion:** update-relevant-tiers
**Eval date:** 2026-08-04
**Overall score:** 0.9653

### Recent Eval History
- evidence-backed-decisions: 100%
- reduce-log-count: 100%
- today-md-archived: 100%
- update-relevant-tiers: 100% <-- TARGET

### What Changed
## Improvement Summary

**Target criterion:** update-relevant-tiers
**Files modified:** skills/memory/consolidate/skill.md

### What changed

Added `## Tier Coverage` to the Step 12 required markdown report sections, and added `update-relevant-tiers` to the required JSON `selfAssessment` keys. Previously, Step 12 listed `## Daily Log Compliance`, `## MEM Audit`, and `## Memory Metrics` as required sections but omitted `## Tier Coverage`, even though MAINTENANCE.md explicitly requires it in every consolidation report. Similarly, `update-relevant-tiers` was not called out in the JSON selfAssessment list.

### Expected impact

Brains following the consolidation skill's Step 12 checklist now have an explicit reminder to include the `## Tier Coverage` section and set `update-relevant-tiers` in `selfAssessment`. This reinforces the MAINTENANCE.md requirement at the point where the agent is writing the report, making it harder to skip and preventing regression of the criterion from its current 1.0 pass rate.

### Skill Impact

**Skill:** memory/consolidate — Memory consolidation procedure run during maintenance sessions
**Behavior change:** Step 12 now explicitly lists `## Tier Coverage` as a required markdown report section and calls out `update-relevant-tiers` as a required JSON selfAssessment key. Brains following the skill's Step 12 checklist will be reminded to include both, complementing the existing MAINTENANCE.md instructions. No other behavior changes.

---
*Auto-generated by brain improvement runner.*
*If scores regress for 2 consecutive days, this PR will be automatically reverted.*