### PR TITLE
fix(consolidate): align Step 9b SUMMARY.md flag threshold with Step 6 trim cap

### DIFF
--- a/skills/memory/consolidate/skill.md
+++ b/skills/memory/consolidate/skill.md
@@ -387,7 +387,7 @@ Measure sizes of key memory files and include a `## Memory Metrics` section in t
 | File | Size (bytes) | Threshold | Status |
 |------|-------------|-----------|--------|
 | CLAUDE.md | 2800 | 10000 | :white_check_mark: |
-| SUMMARY.md | 4200 | 8000 | :white_check_mark: |
+| SUMMARY.md | 4200 | 9000 | :white_check_mark: |
 | LEARNINGS.md | 3100 | 5000 | :white_check_mark: |
 | MEM_REGISTRY.md | 800 | 5000 | :white_check_mark: |
 | PREFERENCES.md | 500 | — | — |
@@ -397,7 +397,7 @@ Measure sizes of key memory files and include a `## Memory Metrics` section in t
 
 **Thresholds** (flag as :warning: if exceeded):
 - `CLAUDE.md` > 10000 — risk: instruction overload
-- `SUMMARY.md` > 8000 — risk: context bloat
+- `SUMMARY.md` > 9000 — risk: context bloat
 - `LEARNINGS.md` > 5000 — risk: too many rules to follow
 - `MEM_REGISTRY.md` > 5000 — risk: registry too large (archive REMOVED entries)
 


### PR DESCRIPTION
## Summary
- Align Step 9b's SUMMARY.md `:warning:` flag threshold (was 8000B) with Step 6's actual inline-trim cap (9000B, added in #229) — removes a 1000B dead zone where reports flagged context-bloat before the system would self-correct.
- Updates both the threshold bullet and the illustrative example row in the Memory Metrics section.
- No other thresholds touched (CLAUDE.md 10000, LEARNINGS.md 5000, MEM_REGISTRY.md 5000 already match their mechanisms).

Follow-up from #155 (closed as superseded by #199 + #229) — full analysis in that issue's closing comment.

## Review
DevGuru ack obtained pre-commit (MEM-29 gate for `skills/memory/*` base-brain changes) — verified scope against the live file (line 292 = Step 6's 9000B cap, lines 390/400 = the two 8000B occurrences), confirmed no other thresholds affected.

## Test plan
- [x] Diff reviewed by DevGuru before commit
- [x] Docs-only change (skill.md), no script/logic touched — no test suite impact
- [x] Grepped repo for other `8000` SUMMARY.md references — none found outside the two changed lines

Closes #278.
