### PR TITLE
fix: cap MEM_REGISTRY.md description length at write time (pb#283)

### DIFF
--- a/skills/memory/scripts/lib/mem-write-core.ts
+++ b/skills/memory/scripts/lib/mem-write-core.ts
@@ -40,3 +40,45 @@ export function getNextKeyFromContents(
   const fromToday = scanMaxKey(todayContent, TODAY_CANONICAL_KEY_PATTERN);
   return Math.max(fromRegistry, fromArchive, fromToday) + 1;
 }
+
+/**
+ * MEM_REGISTRY.md's Description column is meant to be an always-relevant
+ * index, not a second copy of the full narrative — TODAY.md (and later its
+ * archived form under memory/daily/) already holds the verbatim content, so
+ * nothing is lost by capping the registry row itself.
+ *
+ * Reference: poller-brain#283 (feedback: unbounded registry rows, ~1000-1400B
+ * each, drove MEM_REGISTRY.md to 8x the size threshold — same root cause
+ * pb#244/PR#277 trims retroactively; this caps growth at write time instead).
+ */
+export const MAX_REGISTRY_DESC_LENGTH = 300;
+
+/**
+ * Byte-aware (not JS string.length): MEM_REGISTRY.md descriptions are
+ * frequently Czech prose, where diacritics (č/ř/š/ž/é...) are 2B each in
+ * UTF-8. A code-unit-length cap silently lets those rows land 300-450B on
+ * disk, missing the "<=300B" acceptance criterion for a non-hypothetical
+ * share of real descriptions (DevGuru review, poller-brain#283).
+ */
+export function truncateRegistryDescription(
+  desc: string,
+  dailyLogPath: string,
+  maxLength: number = MAX_REGISTRY_DESC_LENGTH
+): string {
+  if (Buffer.byteLength(desc, "utf8") <= maxLength) return desc;
+  const pointer = ` [full: ${dailyLogPath}]`;
+  const ellipsis = "…";
+  const budget =
+    maxLength - Buffer.byteLength(pointer, "utf8") - Buffer.byteLength(ellipsis, "utf8");
+
+  let truncated = "";
+  let bytes = 0;
+  for (const ch of desc) {
+    const chBytes = Buffer.byteLength(ch, "utf8");
+    if (bytes + chBytes > Math.max(0, budget)) break;
+    truncated += ch;
+    bytes += chBytes;
+  }
+  truncated = truncated.trimEnd();
+  return `${truncated}${ellipsis}${pointer}`;
+}

--- a/skills/memory/scripts/mem-write.test.ts
+++ b/skills/memory/scripts/mem-write.test.ts
@@ -10,7 +10,7 @@
  * Exits non-zero on the first failed assertion.
  */
 
-import { getNextKeyFromContents } from "./lib/mem-write-core.js";
+import { getNextKeyFromContents, truncateRegistryDescription, MAX_REGISTRY_DESC_LENGTH } from "./lib/mem-write-core.js";
 
 let passed = 0;
 function assert(cond: boolean, msg: string): void {
@@ -88,6 +88,69 @@ function assert(cond: boolean, msg: string): void {
 {
   const key = getNextKeyFromContents("", "", "");
   assert(key === 1, `fresh brain must start at key 1, got ${key}`);
+}
+
+// --- registry description truncation (pb#283) -------------------------------
+
+// short content passes through unchanged, no pointer added
+{
+  const desc = truncateRegistryDescription("deploy: staging vyžaduje SSO login", "memory/daily/2026-08-07.md");
+  assert(
+    desc === "deploy: staging vyžaduje SSO login",
+    `short desc must be unchanged, got: ${desc}`
+  );
+}
+
+// content over the cap is truncated and gains a pointer, staying within budget
+{
+  const long = "x".repeat(500);
+  const desc = truncateRegistryDescription(long, "memory/daily/2026-08-07.md");
+  assert(
+    desc.length <= MAX_REGISTRY_DESC_LENGTH,
+    `truncated desc must respect the ${MAX_REGISTRY_DESC_LENGTH}B cap, got ${desc.length}B`
+  );
+  assert(
+    desc.includes("[full: memory/daily/2026-08-07.md]"),
+    `truncated desc must carry a pointer to the daily log, got: ${desc}`
+  );
+  assert(desc.startsWith("x"), `truncated desc must retain a content prefix, got: ${desc}`);
+}
+
+// content exactly at the cap is unchanged (boundary, no off-by-one)
+{
+  const exact = "y".repeat(MAX_REGISTRY_DESC_LENGTH);
+  const desc = truncateRegistryDescription(exact, "memory/daily/2026-08-07.md");
+  assert(desc === exact, `desc exactly at cap must be unchanged, got length ${desc.length}`);
+}
+
+// byte-aware cap: Czech diacritics are 2B each in UTF-8, so a string whose
+// JS .length is under the cap can still exceed it in bytes (DevGuru review,
+// pb#283) -- the truncated output must respect the BYTE budget, not code units
+{
+  const czech = "č".repeat(280); // 280 code units, but 560B in UTF-8
+  const desc = truncateRegistryDescription(czech, "memory/daily/2026-08-07.md");
+  const byteLen = Buffer.byteLength(desc, "utf8");
+  assert(
+    byteLen <= MAX_REGISTRY_DESC_LENGTH,
+    `truncated desc must respect the ${MAX_REGISTRY_DESC_LENGTH}B cap in BYTES, got ${byteLen}B (desc.length=${desc.length})`
+  );
+  assert(
+    desc.includes("[full: memory/daily/2026-08-07.md]"),
+    `truncated desc must carry a pointer to the daily log, got: ${desc}`
+  );
+}
+
+// a diacritic-heavy description just under the cap in .length but over it in
+// bytes must still be truncated (this is the exact false-negative DevGuru flagged)
+{
+  const czech300 = "ř".repeat(MAX_REGISTRY_DESC_LENGTH); // .length === 300, but 600B
+  const desc = truncateRegistryDescription(czech300, "memory/daily/2026-08-07.md");
+  assert(
+    desc !== czech300,
+    `a 300-char all-diacritic desc is 600B and must be truncated, not passed through unchanged`
+  );
+  const byteLen = Buffer.byteLength(desc, "utf8");
+  assert(byteLen <= MAX_REGISTRY_DESC_LENGTH, `truncated output must fit the ${MAX_REGISTRY_DESC_LENGTH}B cap, got ${byteLen}B`);
 }
 
 console.log(`✅ all ${passed} assertions passed`);

--- a/skills/memory/scripts/mem-write.ts
+++ b/skills/memory/scripts/mem-write.ts
@@ -16,7 +16,7 @@
 
 import * as fs from "fs";
 import { brainPath } from "./lib/brain-root.js";
-import { getNextKeyFromContents } from "./lib/mem-write-core.js";
+import { getNextKeyFromContents, truncateRegistryDescription } from "./lib/mem-write-core.js";
 
 const REGISTRY_PATH = brainPath("memory/MEM_REGISTRY.md");
 const ARCHIVE_PATH = brainPath("memory/MEM_REGISTRY_ARCHIVE.md");
@@ -79,10 +79,15 @@ function main(): void {
   const today = getToday();
 
   // Escape pipes (markdown table separator) and collapse newlines; keep full content per #150
-  const desc = content.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+  const escaped = content.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
 
-  // Append to TODAY.md
+  // Append to TODAY.md — full, untruncated content is the durable source of
+  // truth (archived verbatim to memory/daily/ by consolidation).
   fs.appendFileSync(TODAY_PATH, `- [MEM-${key}] ${content}\n`);
+
+  // Registry row is capped (#283) — TODAY.md's archived form is the pointer target.
+  const dailyLogPath = `memory/daily/${today}.md`;
+  const desc = truncateRegistryDescription(escaped, dailyLogPath);
 
   // Append to MEM_REGISTRY.md — detect 4 vs 5 column format
   const registry = fs.readFileSync(REGISTRY_PATH, "utf-8");


### PR DESCRIPTION
## Summary
- `mem-write.ts` copied the full prompt into `MEM_REGISTRY.md` with no length cap — rows ~1000-1400B, registry 8x over the 5000B threshold.
- Adds `truncateRegistryDescription()` (byte-aware, UTF-8-safe — code-point iteration, never splits a multi-byte char) to `mem-write-core.ts`, capping new registry rows at 300B.
- `TODAY.md` keeps the full, untruncated content as the durable source of truth (archived verbatim to `memory/daily/` by consolidation) — no data loss.
- Complements pb#244/PR#277 (retroactive trim of existing rows); this caps growth of new rows going forward.

Closes #283

## Review
DevGuru pre-commit consult (MEM-29 gate), full ack after two follow-up rounds:
1. Initial design (pure fn, TODAY.md untouched, no content-scanning) — ack pending byte-awareness check.
2. Flagged the cap was measured in JS `.length` (UTF-16 code units), not bytes — Czech diacritics are 2B/char in UTF-8, so a 300-char Czech description could land 300-450B on disk, missing the "≤300B" acceptance criterion. Fixed: `Buffer.byteLength(desc, 'utf8')` against the cap, truncation walks code points against a byte budget.
3. Flagged the ellipsis char "…" (U+2026) is 3B in UTF-8, not 1 — budget calc must subtract 3, not `-1`. Confirmed already fixed in the same pass (`Buffer.byteLength(ellipsis, 'utf8')`).

Final ack given in Slack thread (C0BJFTSCAP4) 2026-08-07.

## Test plan
- [x] `mem-write.test.ts` 15/15 (11 original + 4 new: pod-cap unchanged, over-cap ASCII, boundary-exact, 2x diacritic byte-cap cases)
- [x] `mem-registry-archive.test.ts` 31/31 (no regression)
- [x] `log-write.test.ts` 6/6 (no regression)
- [x] Manual spot-check: 500x`x`, 280x`č`, 300x`ř`, 305x`a` all truncate to exactly 300B, never over

🤖 Generated with [Claude Code](https://claude.com/claude-code)