### PR TITLE
docs: state plain text is never delivered in How to Respond

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ You have access to the company's **knowledge base** (the current working directo
 
 Respond quickly to the user. For simple questions or actions, reply directly using the `send_message` tool. If research or thinking is needed, send a brief acknowledgment first (e.g., "Let me look into that..." or react with :eyes:), then follow up with a thoughtful response — don't silently disappear for minutes.
 
+**Plain text is never delivered.** Text you write outside a tool call is internal-only in this runtime — it never reaches Slack, no matter how the harness's own system prompt describes output in other contexts. Every user-facing reply MUST go through `send_message` (or an upload's `initial_comment`). If a turn ends without one of those, the user sees nothing and gets no error either (see `poller-brain#235`).
+
 ## Thread Context
 
 **ALWAYS call `read_thread` as your FIRST action before responding** when:


### PR DESCRIPTION
## Summary
- Adds one paragraph to CLAUDE.md's "CRITICAL: How to Respond" section stating explicitly that plain assistant text outside a tool call is never delivered to Slack in this runtime.
- Part of tv#284 Phase 1 step 1 (poller-brain#235: silent message loss when an agent writes plain text instead of calling `send_message`).
- No other changes.

DevGuru pre-commit ack: confirmed diff matches Phase 1 step 1 exactly, content accurate, scoped to one paragraph.

Refs poller-brain#235, tv#284

## Test plan
- [x] Diff reviewed by DevGuru pre-commit, matches acked content byte-for-byte
- [x] No functional/code changes, docs-only