### PR TITLE
draft(pb#299): PostToolUse tamper-guard for .claude/hooks + .claude/skills

### DIFF
--- a/scripts/claude-config-guard/check-bash-diff.mjs
+++ b/scripts/claude-config-guard/check-bash-diff.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// PostToolUse hook (matcher: "Bash") -- other half of the pb#299 tamper-guard pair.
+//
+// After every Bash call, diff the in-scope .claude/hooks/** + .claude/skills/** file set
+// against the last trusted baseline (refreshed by sync-baseline.mjs on Edit/Write calls).
+// Any change not attributable to Edit/Write gets flagged -- regardless of which Bash
+// mechanism made it (`cp`, `sed -i`, `python -c`, `dd`, ...). This checks the RESULT, not
+// the method, so unlike a command-name blocklist it can't be bypassed by a new trick
+// (pb#299, Marosh 2026-08-10: "kontroluje vysledek ne cestu k nemu -- nejde obejit novym
+// trikem").
+//
+// Default: ALERT only (exit 2 + stderr, same convention as review-marker-reminder.sh in
+// individual channel brains). Revert is opt-in via env var CLAUDE_TAMPER_GUARD_MODE=revert
+// -- MEM-75 precedent (this brain's own memory): auto-remediation without an explicit human
+// go is a risk of its own, so the fleet-wide default stays report-only.
+//
+// Known limitations (draft, pending Jakub's product decision on pb#299 before this is
+// enabled anywhere):
+// - Detection is always AFTER the write already landed, never before.
+// - The guard's own definition lives in settings.json, which is OUT OF SCOPE in phase 1 --
+//   a Bash write to settings.json (e.g. deleting the "hooks" key) disables this guard
+//   entirely, silently. Phase 1 does not detect its own disablement.
+// - Baseline state (see lib.mjs) lives in a deterministic path under the OS temp dir,
+//   readable/writable by anything with the same filesystem access as the session --
+//   including the Bash tool this hook watches. DevGuru review (2026-08-10): a Bash call
+//   that deletes the baseline file immediately before writing tampered content lands in
+//   the "no baseline" branch below, which used to trust-and-exit silently -- a one-`rm`
+//   bypass of the exact scenario this guard exists to catch. Fixed by making that branch
+//   alert too (see below); it still can't stop the tamper (baseline is outside the hook's
+//   control), but it stops being invisible. Moving baseline state fully out of Bash's reach
+//   is out of scope for this v1.
+import { execFileSync } from 'node:child_process'
+import { readBaseline, readHookPayload, snapshot, writeBaseline } from './lib.mjs'
+
+const payload = readHookPayload()
+if (!payload) process.exit(0)
+
+const projectDir = payload.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd()
+
+let baseline
+let current
+try {
+  baseline = readBaseline(projectDir)
+  current = snapshot(projectDir)
+} catch {
+  process.exit(0)
+}
+
+if (!baseline) {
+  // No baseline to compare against -- either this is genuinely the first Bash call this
+  // project has ever seen, or an existing baseline was deleted/reset (accidentally by /tmp
+  // cleanup, or deliberately as a bypass -- see the DevGuru note above). Can't tell those
+  // apart from here, and can't retroactively detect tampering that predates this
+  // observation either way -- but trusting-and-exiting SILENTLY (the v1 behavior DevGuru
+  // flagged) makes the deliberate case a one-`rm` invisible bypass. Alerting on every
+  // occurrence, including the benign first-call case, trades noise for visibility: a fresh
+  // baseline is now always a logged event, not just an assumption.
+  try {
+    writeBaseline(projectDir, current)
+  } catch {
+    /* best-effort */
+  }
+  console.error(
+    '[claude-config-guard] No baseline found for .claude/hooks/** / .claude/skills/** in ' +
+      'this project -- trusting current state as the new baseline. If this is the first ' +
+      'Bash call of a fresh session, this is expected. If a baseline should already have ' +
+      'existed, the previous one may have been deleted (accidentally, or as a deliberate ' +
+      'bypass) -- treat as a possible tamper event and check git history / recent Bash ' +
+      'commands for this project\'s .claude/hooks and .claude/skills paths.',
+  )
+  process.exit(2)
+}
+
+const changed = []
+for (const [path, hash] of Object.entries(current)) {
+  if (!(path in baseline)) changed.push({ path, kind: 'added' })
+  else if (baseline[path] !== hash) changed.push({ path, kind: 'modified' })
+}
+for (const path of Object.keys(baseline)) {
+  if (!(path in current)) changed.push({ path, kind: 'deleted' })
+}
+
+if (changed.length === 0) process.exit(0)
+
+const mode = process.env.CLAUDE_TAMPER_GUARD_MODE === 'revert' ? 'revert' : 'alert'
+
+// Tracks the ACTUAL per-file outcome rather than assuming success -- DevGuru review
+// (2026-08-10): the previous version swallowed git checkout/rm failures in the try/catch
+// below and then unconditionally reported "Reverted to the last committed state" in the
+// final message, regardless of whether anything was actually restored. A newly-added,
+// not-yet-committed file is the concrete failure case: `git checkout -- path` has nothing
+// in HEAD to restore from, so it errors and the file is left exactly as tampered.
+const revertResults = new Map()
+
+if (mode === 'revert') {
+  for (const { path, kind } of changed) {
+    try {
+      if (kind === 'added') {
+        execFileSync('rm', ['-f', '--', path], { cwd: projectDir })
+      } else {
+        // Covers both 'modified' and 'deleted' -- git checkout restores either from the
+        // last committed state. Uncommitted-but-legitimate baseline entries (an Edit/Write
+        // change not yet committed) are a known gap of this simple v1: reverted to the
+        // committed version, not the pre-Bash-call baseline. Flagged for the PR review.
+        execFileSync('git', ['checkout', '--', path], { cwd: projectDir })
+      }
+      revertResults.set(path, 'reverted')
+    } catch {
+      revertResults.set(path, 'revert-failed')
+    }
+  }
+  try {
+    writeBaseline(projectDir, snapshot(projectDir))
+  } catch {
+    /* best-effort */
+  }
+}
+
+const lines = changed
+  .map(({ path, kind }) => {
+    const marker = kind === 'added' ? '+' : kind === 'deleted' ? '-' : '~'
+    const outcome = revertResults.has(path) ? ` [${revertResults.get(path)}]` : ''
+    return `  ${marker} ${path} (${kind})${outcome}`
+  })
+  .join('\n')
+
+const anyRevertFailed = [...revertResults.values()].includes('revert-failed')
+
+console.error(
+  `[claude-config-guard] Unexpected change under .claude/hooks/** or .claude/skills/**, ` +
+    `not made via the Edit/Write tool (mode: ${mode}):\n${lines}\n\n` +
+    (mode === 'alert'
+      ? 'NOT reverted (alert-only default). If this change was intentional, make it once ' +
+        'more through the Edit/Write tool to clear this alert on the next Bash call. If it ' +
+        'was not expected, treat it as a possible tamper / prompt-injection event.'
+      : anyRevertFailed
+        ? 'Revert attempted but did NOT fully succeed for all files (see [revert-failed] ' +
+          'above -- typically a newly-added, not-yet-committed file with nothing in git ' +
+          'HEAD to restore from). Treat as still tampered until manually checked.'
+        : 'Reverted to the last committed state.'),
+)
+process.exit(2)

--- a/scripts/claude-config-guard/claude-config-guard.test.mjs
+++ b/scripts/claude-config-guard/claude-config-guard.test.mjs
@@ -1,0 +1,179 @@
+// Tests for the pb#299 tamper-guard hook pair (sync-baseline.mjs / check-bash-diff.mjs).
+// Same style as mcp/__tests__ and skills/background-task — plain node, hand-rolled
+// counters, no framework. Each test runs in its own throwaway git repo under the OS temp
+// dir so baseline state (keyed by project path) never collides between runs.
+//
+//   node scripts/claude-config-guard/claude-config-guard.test.mjs
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SYNC = join(HERE, 'sync-baseline.mjs')
+const CHECK = join(HERE, 'check-bash-diff.mjs')
+
+let pass = 0, fail = 0
+const ok = (n, c, extra) => {
+  if (c) { pass++; console.log('  ✓', n) }
+  else { fail++; console.log('  ✗ FAIL', n, extra !== undefined ? `— ${extra}` : '') }
+}
+
+function freshRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'ccg-test-'))
+  execFileSync('git', ['init', '-q'], { cwd: dir })
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir })
+  execFileSync('git', ['config', 'user.name', 'test'], { cwd: dir })
+  mkdirSync(join(dir, '.claude/hooks'), { recursive: true })
+  mkdirSync(join(dir, '.claude/skills'), { recursive: true })
+  writeFileSync(join(dir, '.claude/hooks/example.sh'), '#!/bin/bash\necho hi\n')
+  execFileSync('git', ['add', '-A'], { cwd: dir })
+  execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: dir })
+  return dir
+}
+
+// Both hooks read a JSON payload on stdin: { cwd, tool_name, tool_input }.
+function runHook(script, payload, env = {}) {
+  try {
+    const out = execFileSync('node', [script], {
+      input: JSON.stringify(payload),
+      cwd: payload.cwd,
+      env: { ...process.env, ...env },
+    })
+    return { code: 0, stdout: out.toString(), stderr: '' }
+  } catch (e) {
+    return { code: e.status, stdout: (e.stdout || '').toString(), stderr: (e.stderr || '').toString() }
+  }
+}
+
+function cleanBaselineFor(dir) {
+  // Clear any baseline left by a prior run keyed to this exact tmp path (fresh mkdtemp
+  // path each call makes this a no-op in practice, but keeps runs order-independent).
+  const key = execFileSync('node', ['-e', `
+    const { createHash } = require('node:crypto')
+    process.stdout.write(createHash('sha256').update(process.argv[1]).digest('hex'))
+  `, dir]).toString()
+  const p = join(tmpdir(), 'claude-tamper-guard', `${key}.json`)
+  if (existsSync(p)) rmSync(p)
+}
+
+// 1) First Bash observation for a fresh project: no baseline yet → trust current state as
+//    the new baseline, but ALERT (not silent) -- DevGuru 08-10: a silent trust-and-exit
+//    here is a one-`rm` bypass (delete the baseline file, then tamper, and it looks exactly
+//    like a fresh project). Noisy on every genuinely-first call, by design.
+{
+  const dir = freshRepo()
+  cleanBaselineFor(dir)
+  const r = runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'ls' } })
+  ok('first observation: exits 2 (alerts, does not silently trust)', r.code === 2)
+  ok('first observation: stderr explains no-baseline case', r.stderr.includes('No baseline found'))
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// 2) Untracked Bash write (simulating `cp`) after baseline exists → flagged, alert-only by
+//    default, file NOT reverted.
+{
+  const dir = freshRepo()
+  cleanBaselineFor(dir)
+  runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'ls' } }) // seeds baseline
+  writeFileSync(join(dir, '.claude/hooks/example.sh'), '#!/bin/bash\necho PWNED\n') // simulates cp bypass
+  const r = runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'cp /tmp/x .claude/hooks/example.sh' } })
+  ok('untracked write: exit 2 (alert)', r.code === 2)
+  ok('untracked write: names the changed file', r.stderr.includes('example.sh'))
+  ok('untracked write: alert mode does not revert', readFileSync(join(dir, '.claude/hooks/example.sh'), 'utf8').includes('PWNED'))
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// 3) Same as #2 but with CLAUDE_TAMPER_GUARD_MODE=revert → file restored from git.
+{
+  const dir = freshRepo()
+  cleanBaselineFor(dir)
+  runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'ls' } })
+  writeFileSync(join(dir, '.claude/hooks/example.sh'), '#!/bin/bash\necho PWNED\n')
+  const r = runHook(
+    CHECK,
+    { cwd: dir, tool_name: 'Bash', tool_input: { command: 'cp /tmp/x .claude/hooks/example.sh' } },
+    { CLAUDE_TAMPER_GUARD_MODE: 'revert' },
+  )
+  ok('revert mode: exit 2 (still reports)', r.code === 2)
+  ok('revert mode: restores committed content', !readFileSync(join(dir, '.claude/hooks/example.sh'), 'utf8').includes('PWNED'))
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// 4) Legitimate change via Edit/Write (sync-baseline.mjs) → next Bash call does NOT flag it.
+{
+  const dir = freshRepo()
+  cleanBaselineFor(dir)
+  runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'ls' } }) // seed
+  writeFileSync(join(dir, '.claude/hooks/example.sh'), '#!/bin/bash\necho legit-change\n')
+  runHook(SYNC, { cwd: dir, tool_name: 'Edit', tool_input: { file_path: '.claude/hooks/example.sh' } })
+  const r = runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'ls' } })
+  ok('Edit/Write-mediated change: not flagged on next Bash call', r.code === 0)
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// 5) Out-of-scope Edit (outside .claude/hooks or .claude/skills) → sync-baseline is a no-op.
+{
+  const dir = freshRepo()
+  cleanBaselineFor(dir)
+  writeFileSync(join(dir, 'README.md'), 'hello')
+  const r = runHook(SYNC, { cwd: dir, tool_name: 'Edit', tool_input: { file_path: 'README.md' } })
+  ok('out-of-scope Edit: exits 0, no crash', r.code === 0)
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// 6) New file added under .claude/skills via Bash (not just modified) → flagged as added.
+{
+  const dir = freshRepo()
+  cleanBaselineFor(dir)
+  runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'ls' } })
+  writeFileSync(join(dir, '.claude/skills/new-script.mjs'), 'console.log(1)')
+  const r = runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'touch .claude/skills/new-script.mjs' } })
+  ok('new file under scope: flagged as added', r.code === 2 && r.stderr.includes('new-script.mjs') && r.stderr.includes('added'))
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// 7) Revert mode on a NEW (never-committed) file: `git checkout` has nothing in HEAD to
+//    restore -- the report must say so (not claim success it didn't achieve). DevGuru
+//    08-10: the v1 version unconditionally printed "Reverted to the last committed state"
+//    even when the underlying git/rm call had failed.
+{
+  const dir = freshRepo()
+  cleanBaselineFor(dir)
+  runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'ls' } }) // seed
+  writeFileSync(join(dir, '.claude/hooks/brand-new.sh'), '#!/bin/bash\necho PWNED\n')
+  const r = runHook(
+    CHECK,
+    { cwd: dir, tool_name: 'Bash', tool_input: { command: 'cp /tmp/x .claude/hooks/brand-new.sh' } },
+    { CLAUDE_TAMPER_GUARD_MODE: 'revert' },
+  )
+  // 'added' kind -> code path is `rm -f`, which DOES succeed on a real file (unlike
+  // `git checkout` on an untracked path) -- covers the other failure mode: rm succeeds, so
+  // the file WAS actually removed, and the report must match that outcome, not fake success.
+  ok('revert of new file: reports reverted (rm succeeds)', r.stderr.includes('[reverted]'))
+  ok('revert of new file: file actually gone', !existsSync(join(dir, '.claude/hooks/brand-new.sh')))
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// 8) Revert mode on a MODIFIED but never-committed baseline entry (git checkout fails --
+//    nothing in HEAD for this exact content/path combo simulated by removing the file from
+//    git's index while keeping it in the baseline) reports revert-failed honestly.
+{
+  const dir = freshRepo()
+  cleanBaselineFor(dir)
+  runHook(CHECK, { cwd: dir, tool_name: 'Bash', tool_input: { command: 'ls' } }) // seed baseline (has example.sh)
+  execFileSync('git', ['rm', '-q', '--cached', '.claude/hooks/example.sh'], { cwd: dir }) // now untracked from git's POV, but still in our baseline
+  writeFileSync(join(dir, '.claude/hooks/example.sh'), '#!/bin/bash\necho PWNED\n')
+  const r = runHook(
+    CHECK,
+    { cwd: dir, tool_name: 'Bash', tool_input: { command: 'cp /tmp/x .claude/hooks/example.sh' } },
+    { CLAUDE_TAMPER_GUARD_MODE: 'revert' },
+  )
+  ok('revert of untracked-modified file: reports revert-failed', r.stderr.includes('revert-failed'))
+  ok('revert of untracked-modified file: message says still tampered', r.stderr.includes('still tampered'))
+  rmSync(dir, { recursive: true, force: true })
+}
+
+console.log(`\n${pass} passed, ${fail} failed`)
+process.exit(fail > 0 ? 1 : 0)

--- a/scripts/claude-config-guard/lib.mjs
+++ b/scripts/claude-config-guard/lib.mjs
@@ -1,0 +1,92 @@
+// Shared helpers for the pb#299 tamper-guard hook pair (sync-baseline.mjs +
+// check-bash-diff.mjs). Not a hook itself -- imported by both.
+//
+// Phase 1 scope is deliberately narrow: executable/re-run content only
+// (.claude/hooks/**, .claude/skills/**). settings.json, commands/, agents/ are phase 2
+// -- DevGuru 08-10 (pb#299 thread): the exposure window this hook leaves (change lands,
+// then gets caught on the *next* Bash call) only matters for content that gets re-executed
+// mid-session. settings.json and commands/agents markdown don't hot-reload, so a same-
+// session change there has no live-exploit window even before detection catches up.
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+
+export const SCOPE_DIRS = ['.claude/hooks', '.claude/skills']
+
+function walk(dir, projectDir, out) {
+  if (!existsSync(dir)) return
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) walk(full, projectDir, out)
+    else if (entry.isFile()) out.push(relative(projectDir, full))
+  }
+}
+
+export function listScopedFiles(projectDir) {
+  const out = []
+  for (const rel of SCOPE_DIRS) walk(join(projectDir, rel), projectDir, out)
+  return out.sort()
+}
+
+export function isInScope(relPath) {
+  return SCOPE_DIRS.some((d) => relPath === d || relPath.startsWith(`${d}/`))
+}
+
+export function hashFile(absPath) {
+  return createHash('sha256').update(readFileSync(absPath)).digest('hex')
+}
+
+export function snapshot(projectDir) {
+  const map = {}
+  for (const rel of listScopedFiles(projectDir)) {
+    map[rel] = hashFile(join(projectDir, rel))
+  }
+  return map
+}
+
+// Baseline state lives in the OS temp dir, keyed by project path -- never inside the
+// brain's own git tree. Keeps the guard's own state file out of `git status`/diffs and out
+// of scope for the very scan it drives; resets safely (fail-open to "trust current state")
+// if /tmp is cleared or a fresh checkout is used.
+//
+// KNOWN GAP verified against teamvibe.ai source (DevGuru review, 2026-08-10): cron/
+// maintenance sessions run in an ephemeral git worktree at
+// `<brain>/.worktrees/<thread_id>/` (claude-spawner.ts, teamvibeai/teamvibe.ai#120),
+// removed after the session ends, with a fresh thread_id (and therefore a different
+// `projectDir`) EVERY run (see scheduler.ts's `scheduled:<scheduleId>:${Date.now()}`).
+// Since the baseline key here is derived from `projectDir`, this guarantees the "no
+// baseline" branch in check-bash-diff.mjs fires on literally every cron/maintenance
+// session's first Bash call, not just on genuine resets -- alert-fatigue risk that needs a
+// real fix (stable key independent of the worktree path, e.g. derived from the brain's own
+// origin URL) before this guard is turned on for autonomous sessions. Interactive Slack
+// sessions are unaffected (`ISOLATED_SOURCES` excludes 'slack' -- they run in the stable
+// main brain dir, per claude-spawner.ts:1044-1051).
+function baselinePath(projectDir) {
+  const key = createHash('sha256').update(projectDir).digest('hex')
+  const dir = join(tmpdir(), 'claude-tamper-guard')
+  mkdirSync(dir, { recursive: true })
+  return join(dir, `${key}.json`)
+}
+
+export function readBaseline(projectDir) {
+  const p = baselinePath(projectDir)
+  if (!existsSync(p)) return null
+  try {
+    return JSON.parse(readFileSync(p, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+export function writeBaseline(projectDir, snap) {
+  writeFileSync(baselinePath(projectDir), JSON.stringify(snap))
+}
+
+export function readHookPayload() {
+  try {
+    return JSON.parse(readFileSync(0, 'utf8'))
+  } catch {
+    return null
+  }
+}

--- a/scripts/claude-config-guard/sync-baseline.mjs
+++ b/scripts/claude-config-guard/sync-baseline.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// PostToolUse hook (matcher: "Edit|Write") -- one half of the pb#299 tamper-guard pair.
+//
+// After every Edit/Write call that touches an in-scope .claude/** path, refresh the
+// trusted baseline so check-bash-diff.mjs (the other half, matcher: "Bash") doesn't flag
+// legitimate, tool-mediated changes on the next Bash call.
+//
+// Caveat, flagged by DevGuru in the pb#299 review thread (2026-08-10): this treats EVERY
+// Edit/Write write as trusted, including one made by a compromised/prompt-injected agent
+// using Edit/Write itself. That is a different threat this pair does not defend against --
+// it only distinguishes "went through the Edit/Write tool" (attributable in the session
+// transcript) from "did not" (e.g. `cp`, `sed -i`, `python -c` from Bash), not "was
+// reviewed by a human". See pb#299 for the fuller threat-model discussion.
+//
+// Fails open: any error here (bad/missing stdin JSON, unreadable file) exits 0 rather than
+// blocking the tool call that already completed -- PostToolUse hooks report on a call that
+// already happened, so there is nothing left to "block".
+import { relative, resolve } from 'node:path'
+import { isInScope, readHookPayload, snapshot, writeBaseline } from './lib.mjs'
+
+const payload = readHookPayload()
+if (!payload) process.exit(0)
+
+const projectDir = payload.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd()
+const filePath = payload.tool_input?.file_path
+if (!filePath) process.exit(0)
+
+let rel
+try {
+  rel = relative(projectDir, resolve(projectDir, filePath))
+} catch {
+  process.exit(0)
+}
+
+if (!isInScope(rel)) process.exit(0)
+
+try {
+  writeBaseline(projectDir, snapshot(projectDir))
+} catch {
+  // Best-effort. A failed baseline refresh just means the next Bash-side check may
+  // false-positive on this legitimate change -- annoying, not unsafe (alert-only default).
+}
+process.exit(0)

--- a/settings.json
+++ b/settings.json
@@ -14,5 +14,27 @@
       "mcp__slack__*",
       "mcp__teamvibe-api__*"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $CLAUDE_CONFIG_DIR/scripts/claude-config-guard/sync-baseline.mjs"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $CLAUDE_CONFIG_DIR/scripts/claude-config-guard/check-bash-diff.mjs"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## ⚠️ NOT FOR MERGE

This is a **draft to give Jakub a concrete basis for the pb#299 product decision** — not
ready to ship. Do not merge until that decision lands (see pb#299 and the pb#299 Slack
thread, 2026-08-10).

## Context

pb#299: `.claude/**` write-protection is asymmetric depending on which mechanism performs
the write (`cp`/similar Bash paths succeed silently; `mkdir` hard-blocks; `rm`/`mv` on an
existing file hits a permission-prompt with no approver in an autonomous session).

**Reframe during analysis (see pb#299 thread):** `.claude/**` Edit/Write access has been
unrestricted fleet-wide, on purpose, since poller-brain#51 (2026-04-26) — verified live via
`$CLAUDE_CONFIG_DIR/settings.json`. So `cp` isn't bypassing a human-approval gate that
Edit/Write itself respects; Edit/Write has identical unrestricted access. This PR is a
tamper-**detection** mechanism (distinguishing "went through Edit/Write" — attributable in
the session transcript — from "did not"), not a re-introduction of an approval gate #51
deliberately removed.

**Two independent questions for Jakub, not one** (DevGuru caught this distinction before it
got compressed into a single misleading yes/no):
1. Should routine agent self-writes to their own `.claude/**` require approval? (#51 already
   answered: no, intentionally, for agent convenience.)
2. Do we want tamper-detection/audit for *unusual* `.claude/**` writes outside Edit/Write
   (e.g. a prompt-injection forcing an agent to rewrite its own hooks or permissions)? This
   is independent of #1 and unaddressed by #51.

This PR is a concrete answer to question 2, to review alongside the question — not a
unilateral decision to implement it.

## What this does

Two PostToolUse hooks (`scripts/claude-config-guard/`), wired into base-brain `settings.json`:

- **`sync-baseline.mjs`** (matcher `Edit|Write`) — after every Edit/Write call touching
  `.claude/hooks/**` or `.claude/skills/**`, refreshes a trusted sha256 baseline for that
  file.
- **`check-bash-diff.mjs`** (matcher `Bash`) — after every Bash call, diffs the in-scope
  file set against the last baseline. Any change not attributable to Edit/Write is flagged,
  regardless of mechanism (`cp`, `sed -i`, `python -c`, `dd`, ...) — detects the *result*,
  not the *method*, so it can't be evaded by a new trick the way a command blocklist could
  (h/t Marosh for this framing).

Default mode: **alert-only** (exit 2 + stderr, matches `review-marker-reminder.sh`
convention). Revert is opt-in via `CLAUDE_TAMPER_GUARD_MODE=revert` — per this brain's own
MEM-75 precedent, auto-remediation without an explicit human go is a risk of its own, so the
fleet-wide default stays report-only.

## Scope (phase 1 of 2)

Per DevGuru's recommendation: only `.claude/hooks/**` and `.claude/skills/**` (executable /
re-run content) for now. `settings.json`, `commands/`, `agents/` are phase 2 — deferred
because they don't hot-reload mid-session, so a same-session change there has no live-exploit
window even before detection catches up.

## Review history (both rounds addressed before this push)

- **Round 1** (DevGuru): found the revert-mode report always claimed success even when the
  underlying `git checkout`/`rm` had silently failed, and the "no baseline" branch trusted
  and exited silently — a one-`rm` bypass of the exact scenario this guard exists to catch.
  Both fixed: per-file outcome tracking + report; "no baseline" branch now always alerts
  (including the benign first-Bash-call case — noise traded for visibility, DevGuru's
  explicit call).
- **Round 2** (DevGuru): confirmed the `Edit|Write` matcher regex against Claude Code hooks
  docs (standard pattern, no risk) and acked the round-1 fixes. Flagged a new **known,
  unresolved gap** (not a push-blocker, needs solving before this is ever enabled): cron/
  maintenance sessions run in an ephemeral git worktree
  (`<brain>/.worktrees/<thread_id>/`, `teamvibeai/teamvibe.ai#120`) with a fresh path every
  run, and baseline state here is keyed by that path — so the "no baseline" branch would
  fire on literally every autonomous session's first Bash call, not just genuine resets.
  Verified directly against `teamvibeai/teamvibe.ai` source
  (`packages/poller/src/claude-spawner.ts`, `ISOLATED_SOURCES`). Interactive Slack sessions
  are unaffected (stable main-brain working dir). **This needs a real fix (baseline key
  independent of the worktree path) before this guard could be turned on for autonomous
  sessions** — documented in `lib.mjs`, not solved in this draft.

## Known limitations (full detail in code comments)

- Detection is always after the write lands, never before.
- Baseline is trusted-on-first-observation — can't retroactively detect tampering that
  predates the hook (mitigated, not solved, by always alerting on that branch now).
- Baseline state lives in a deterministic `/tmp` path reachable by the same Bash session it
  watches. Moving it fully out of Bash's reach is out of scope for v1.
- **`settings.json` (where these hooks are defined) is itself out of scope in phase 1** — a
  Bash write to `settings.json`, or deletion of the `hooks` key, disables this guard
  entirely, undetected.
- Treats *all* Edit/Write writes as trusted, including a compromised/prompt-injected agent
  using Edit/Write itself — a different threat, out of scope here.
- **Cron/maintenance baseline-key-vs-ephemeral-worktree gap** — see round 2 above. Needs a
  fix before enabling for autonomous sessions.

## Test plan

- [x] `node scripts/claude-config-guard/claude-config-guard.test.mjs` — 14/14 passing
      locally (first-observation alert, alert-mode leaves file untouched, opt-in revert
      restores from git, Edit/Write-mediated changes not flagged, out-of-scope Edit no-op,
      new-file-under-scope detection, revert-succeeds vs revert-fails honest reporting)
- [ ] Live verification of the `Edit|Write` / `Bash` hook matchers against a real Claude
      Code session (DevGuru confirmed the syntax against docs; not yet live-tested end to
      end, same caveat pattern as `review-marker-reminder.sh`)
- [ ] Jakub's product decision on the two questions above
- [ ] Fix for the cron/maintenance baseline-key gap, if this proceeds past draft

Refs: pb#299

🤖 Generated with [Claude Code](https://claude.com/claude-code)